### PR TITLE
added error to getPositions

### DIFF
--- a/src/core/utils/filters.ts
+++ b/src/core/utils/filters.ts
@@ -1,22 +1,3 @@
-import { logger } from './logger'
-
-export const fulfilledPromises = <Return>(
-  results: PromiseSettledResult<Return>[],
-): Return[] => {
-  results.forEach((p) => {
-    if (p.status !== 'fulfilled') {
-      logger.error(p, 'Unfulfilled promise detected:')
-    }
-  })
-
-  return results
-    .filter(
-      (p: PromiseSettledResult<Return>): p is PromiseFulfilledResult<Return> =>
-        p.status === 'fulfilled',
-    )
-    .map((p) => p.value)
-}
-
 export const filterMap = <Input, Return>(
   array: Input[],
   callback: (value: Input, index: number, array: Input[]) => Return | undefined,

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,23 +3,17 @@ import { Protocol, supportedProtocols } from './adapters'
 import { Chain } from './core/constants/chains'
 import { chainProviders } from './core/utils/chainProviders'
 import { logger } from './core/utils/logger'
-import { IProtocolAdapter, ProfitsTokensWithRange } from './types/adapter'
+import { IProtocolAdapter } from './types/adapter'
 import {
   APRResponse,
   APYResponse,
   AdapterResponse,
   DefiMovementsResponse,
   DefiPositionResponse,
-  DefiPositions,
   DefiProfitsResponse,
   AdapterError,
   PricePerShareResponse,
   TotalValueLockResponse,
-  PricePerShare,
-  APR,
-  DefiMovements,
-  APY,
-  TotalValueLock,
 } from './types/response'
 
 export async function getPositions({
@@ -31,7 +25,7 @@ export async function getPositions({
   filterProtocolIds?: Protocol[]
   filterChainIds?: Chain[]
 }): Promise<DefiPositionResponse[]> {
-  const runner = async (adapter: IProtocolAdapter): Promise<DefiPositions> => {
+  const runner = async (adapter: IProtocolAdapter) => {
     const tokens = await adapter.getPositions({
       userAddress,
     })
@@ -58,7 +52,7 @@ export async function getTodaysProfits({
   const runner = async (
     adapter: IProtocolAdapter,
     provider: ethers.JsonRpcProvider,
-  ): Promise<ProfitsTokensWithRange> => {
+  ) => {
     const blockNumber = await provider.getBlockNumber()
     return await adapter.getOneDayProfit({
       userAddress,
@@ -80,7 +74,7 @@ export async function getPrices({
   filterProtocolIds?: Protocol[]
   filterChainIds?: Chain[]
 }): Promise<PricePerShareResponse[]> {
-  const runner = async (adapter: IProtocolAdapter): Promise<PricePerShare> => {
+  const runner = async (adapter: IProtocolAdapter) => {
     const protocolTokens = await adapter.getProtocolTokens()
     const tokens = await Promise.all(
       protocolTokens.map(({ address: protocolTokenAddress }) =>
@@ -105,7 +99,7 @@ export async function getTotalValueLocked({
   filterProtocolIds?: Protocol[]
   filterChainIds?: Chain[]
 }): Promise<TotalValueLockResponse[]> {
-  const runner = async (adapter: IProtocolAdapter): Promise<TotalValueLock> => {
+  const runner = async (adapter: IProtocolAdapter) => {
     const tokens = await adapter.getTotalValueLocked({})
 
     return { tokens }
@@ -125,7 +119,7 @@ export async function getApy({
   filterProtocolIds?: Protocol[]
   filterChainIds?: Chain[]
 }): Promise<APYResponse[]> {
-  const runner = async (adapter: IProtocolAdapter): Promise<APY> => {
+  const runner = async (adapter: IProtocolAdapter) => {
     const protocolTokens = await adapter.getProtocolTokens()
     const tokens = await Promise.all(
       protocolTokens.map(({ address: protocolTokenAddress }) =>
@@ -158,7 +152,7 @@ export async function getDeposits({
   fromBlock: number
   toBlock: number
 }): Promise<DefiMovementsResponse[]> {
-  const runner = async (adapter: IProtocolAdapter): Promise<DefiMovements> => {
+  const runner = async (adapter: IProtocolAdapter) => {
     const protocolTokens = await adapter.getProtocolTokens()
     const movements = await Promise.all(
       protocolTokens.map(async (protocolToken) => {
@@ -201,7 +195,7 @@ export async function getWithdrawals({
   fromBlock: number
   toBlock: number
 }): Promise<DefiMovementsResponse[]> {
-  const runner = async (adapter: IProtocolAdapter): Promise<DefiMovements> => {
+  const runner = async (adapter: IProtocolAdapter) => {
     const protocolTokens = await adapter.getProtocolTokens()
     const movements = await Promise.all(
       protocolTokens.map(async (protocolToken) => {
@@ -238,7 +232,7 @@ export async function getApr({
   filterProtocolIds?: Protocol[]
   filterChainIds?: Chain[]
 }): Promise<APRResponse[]> {
-  const runner = async (adapter: IProtocolAdapter): Promise<APR> => {
+  const runner = async (adapter: IProtocolAdapter) => {
     const protocolTokens = await adapter.getProtocolTokens()
     const tokens = await Promise.all(
       protocolTokens.map(({ address: protocolTokenAddress }) =>
@@ -339,7 +333,5 @@ async function runForAllProtocolsAndChains<ReturnType extends object>({
         })
     })
 
-  const results = await Promise.all(protocolPromises)
-
-  return results
+  return Promise.all(protocolPromises)
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ import {
   DefiMovementsResponse,
   DefiPositionResponse,
   DefiProfitsResponse,
-  AdapterError,
+  AdapterErrorResponse,
   PricePerShareResponse,
   TotalValueLockResponse,
 } from './types/response'
@@ -303,7 +303,7 @@ async function runForAllProtocolsAndChains<ReturnType extends object>({
                 ...adapterResult,
               }
             } catch (error) {
-              let adapterError: AdapterError['error']
+              let adapterError: AdapterErrorResponse['error']
 
               if (error instanceof Error) {
                 adapterError = {

--- a/src/types/response.ts
+++ b/src/types/response.ts
@@ -10,29 +10,46 @@ import {
   ProtocolTotalValueLockedToken,
 } from './adapter'
 
-export type DefiPositionResponse = ProtocolDetails & {
+export type AdapterError = {
+  error: {
+    message: string
+    details?: object
+  }
+}
+
+export type AdapterResponse<T> = ProtocolDetails & (T | AdapterError)
+
+export type DefiPositions = {
   tokens: ProtocolToken[]
 }
+export type DefiPositionResponse = AdapterResponse<DefiPositions>
 
-export type PricePerShareResponse = ProtocolDetails & {
+export type PricePerShare = {
   tokens: ProtocolPricePerShareToken[]
 }
-export type APRResponse = ProtocolDetails & {
+export type PricePerShareResponse = AdapterResponse<PricePerShare>
+
+export type APR = {
   tokens: ProtocolAprToken[]
 }
-export type APYResponse = ProtocolDetails & {
+export type APRResponse = AdapterResponse<APR>
+
+export type APY = {
   tokens: ProtocolApyToken[]
 }
+export type APYResponse = AdapterResponse<APY>
 
-export type TotalValueLockResponse = ProtocolDetails & {
+export type TotalValueLock = {
   tokens: ProtocolTotalValueLockedToken[]
 }
+export type TotalValueLockResponse = AdapterResponse<TotalValueLock>
 
-export type DefiProfitsResponse = ProtocolDetails & ProfitsTokensWithRange
+export type DefiProfitsResponse = AdapterResponse<ProfitsTokensWithRange>
 
-export type DefiMovementsResponse = ProtocolDetails & {
+export type DefiMovements = {
   movements: {
     protocolToken: Erc20Metadata
     positionMovements: MovementsByBlock[]
   }[]
 }
+export type DefiMovementsResponse = AdapterResponse<DefiMovements>

--- a/src/types/response.ts
+++ b/src/types/response.ts
@@ -19,37 +19,31 @@ export type AdapterError = {
 
 export type AdapterResponse<T> = ProtocolDetails & (T | AdapterError)
 
-export type DefiPositions = {
+export type DefiPositionResponse = AdapterResponse<{
   tokens: ProtocolToken[]
-}
-export type DefiPositionResponse = AdapterResponse<DefiPositions>
+}>
 
-export type PricePerShare = {
+export type PricePerShareResponse = AdapterResponse<{
   tokens: ProtocolPricePerShareToken[]
-}
-export type PricePerShareResponse = AdapterResponse<PricePerShare>
+}>
 
-export type APR = {
+export type APRResponse = AdapterResponse<{
   tokens: ProtocolAprToken[]
-}
-export type APRResponse = AdapterResponse<APR>
+}>
 
-export type APY = {
+export type APYResponse = AdapterResponse<{
   tokens: ProtocolApyToken[]
-}
-export type APYResponse = AdapterResponse<APY>
+}>
 
-export type TotalValueLock = {
+export type TotalValueLockResponse = AdapterResponse<{
   tokens: ProtocolTotalValueLockedToken[]
-}
-export type TotalValueLockResponse = AdapterResponse<TotalValueLock>
+}>
 
 export type DefiProfitsResponse = AdapterResponse<ProfitsTokensWithRange>
 
-export type DefiMovements = {
+export type DefiMovementsResponse = AdapterResponse<{
   movements: {
     protocolToken: Erc20Metadata
     positionMovements: MovementsByBlock[]
   }[]
-}
-export type DefiMovementsResponse = AdapterResponse<DefiMovements>
+}>

--- a/src/types/response.ts
+++ b/src/types/response.ts
@@ -10,14 +10,14 @@ import {
   ProtocolTotalValueLockedToken,
 } from './adapter'
 
-export type AdapterError = {
+export type AdapterErrorResponse = {
   error: {
     message: string
     details?: object
   }
 }
 
-export type AdapterResponse<T> = ProtocolDetails & (T | AdapterError)
+export type AdapterResponse<T> = ProtocolDetails & (T | AdapterErrorResponse)
 
 export type DefiPositionResponse = AdapterResponse<{
   tokens: ProtocolToken[]

--- a/src/types/response.ts
+++ b/src/types/response.ts
@@ -17,7 +17,8 @@ export type AdapterErrorResponse = {
   }
 }
 
-export type AdapterResponse<T> = ProtocolDetails & (T | AdapterErrorResponse)
+export type AdapterResponse<ProtocolResponse> = ProtocolDetails &
+  (ProtocolResponse | AdapterErrorResponse)
 
 export type DefiPositionResponse = AdapterResponse<{
   tokens: ProtocolToken[]


### PR DESCRIPTION
- Catch the error from the adapter and include it along with the protocol details
- Works with `throw new Error('XXX')` and with custom errors that extend `Error`.
- It has fallbacks in case a call returns a `string` instead of an error.

Examples:
If a provider for a queries chain is missing:
```
  {
    "protocolId": "stargate",
    "name": "Stargate",
    "description": "Stargate is a fully composable liquidity transport protocol that lives at the heart of Omnichain DeFi",
    "siteUrl": "https://stargate.finance/",
    "iconUrl": "https://stargate.finance/favicons/favicon-light.svg",
    "positionType": "supply",
    "chainId": 42161,
    "error": {
      "message": "No provider found for chain",
      "details": {
        "chainId": 42161,
        "chainName": "arbitrum"
      }
    }
  },
```

If the adapter throws an error (in this case, profits is not implemented for stargate vesting adapter, so `throw new Error('Not implemented')`.
```
{
    "protocolId": "stargate",
    "name": "Stargate",
    "description": "Stargate is a fully composable liquidity transport protocol that lives at the heart of Omnichain DeFi",
    "siteUrl": "https://stargate.finance/",
    "iconUrl": "https://stargate.finance/favicons/favicon-light.svg",
    "positionType": "stake",
    "chainId": 1,
    "error": {
      "message": "Not Implemented",
      "details": {
        "name": "Error"
      }
    }
  },
```