### PR TITLE
feat: stableBlockNumber

### DIFF
--- a/docs/modules/adapter.md
+++ b/docs/modules/adapter.md
@@ -58,7 +58,7 @@
 
 [adapter.ts:11](https://github.com/consensys-vertical-apps/mmi-defi-adapters/blob/main/src/types/adapter.ts#L11)
 
-___
+---
 
 ### PositionType
 
@@ -70,17 +70,17 @@ ___
 
 [adapter.ts:34](https://github.com/consensys-vertical-apps/mmi-defi-adapters/blob/main/src/types/adapter.ts#L34)
 
-___
+---
 
 ### GetBalancesInput
 
-Ƭ **GetBalancesInput**: [`GetPositionsInput`](../interfaces/adapter.GetPositionsInput.md) & { `provider`: `ethers.JsonRpcProvider` ; `chainId`: `Chain` ; `tokens`: [`Erc20Metadata`](erc20Metadata.md#erc20metadata)[]  }
+Ƭ **GetBalancesInput**: [`GetPositionsInput`](../interfaces/adapter.GetPositionsInput.md) & { `provider`: `CustomJsonRpcProvider ; `chainId`: `Chain`;`tokens`: [`Erc20Metadata`](erc20Metadata.md#erc20metadata)[] }
 
 #### Defined in
 
 [adapter.ts:36](https://github.com/consensys-vertical-apps/mmi-defi-adapters/blob/main/src/types/adapter.ts#L36)
 
-___
+---
 
 ### GetConversionRateInput
 
@@ -88,16 +88,16 @@ ___
 
 #### Type declaration
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `blockNumber?` | `number` | Optional override param |
+| Name                   | Type     | Description                                |
+| :--------------------- | :------- | :----------------------------------------- |
+| `blockNumber?`         | `number` | Optional override param                    |
 | `protocolTokenAddress` | `string` | Protocol token address (LP token address). |
 
 #### Defined in
 
 [adapter.ts:42](https://github.com/consensys-vertical-apps/mmi-defi-adapters/blob/main/src/types/adapter.ts#L42)
 
-___
+---
 
 ### GetApyInput
 
@@ -105,16 +105,16 @@ ___
 
 #### Type declaration
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `blockNumber?` | `number` | Optional override param |
+| Name                   | Type     | Description                                |
+| :--------------------- | :------- | :----------------------------------------- |
+| `blockNumber?`         | `number` | Optional override param                    |
 | `protocolTokenAddress` | `string` | Protocol token address (LP token address). |
 
 #### Defined in
 
 [adapter.ts:52](https://github.com/consensys-vertical-apps/mmi-defi-adapters/blob/main/src/types/adapter.ts#L52)
 
-___
+---
 
 ### GetAprInput
 
@@ -122,16 +122,16 @@ ___
 
 #### Type declaration
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `blockNumber?` | `number` | Optional override param |
+| Name                   | Type     | Description                                |
+| :--------------------- | :------- | :----------------------------------------- |
+| `blockNumber?`         | `number` | Optional override param                    |
 | `protocolTokenAddress` | `string` | Protocol token address (LP token address). |
 
 #### Defined in
 
 [adapter.ts:63](https://github.com/consensys-vertical-apps/mmi-defi-adapters/blob/main/src/types/adapter.ts#L63)
 
-___
+---
 
 ### GetEventsInput
 
@@ -139,18 +139,18 @@ ___
 
 #### Type declaration
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `userAddress` | `string` | User address we want to get events for |
-| `protocolTokenAddress` | `string` | Protocol token we want to check related events for |
-| `fromBlock` | `number` | Starting blocknumber to check from |
-| `toBlock` | `number` | End blocknumber we want to check to e.g. current blocknumber |
+| Name                   | Type     | Description                                                  |
+| :--------------------- | :------- | :----------------------------------------------------------- |
+| `userAddress`          | `string` | User address we want to get events for                       |
+| `protocolTokenAddress` | `string` | Protocol token we want to check related events for           |
+| `fromBlock`            | `number` | Starting blocknumber to check from                           |
+| `toBlock`              | `number` | End blocknumber we want to check to e.g. current blocknumber |
 
 #### Defined in
 
 [adapter.ts:74](https://github.com/consensys-vertical-apps/mmi-defi-adapters/blob/main/src/types/adapter.ts#L74)
 
-___
+---
 
 ### ProtocolDetails
 
@@ -158,14 +158,14 @@ ___
 
 #### Type declaration
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `protocolId` | `Protocol` | Unique protocol id |
-| `chainId` | `Chain` | Chain this adapter is for |
-| `name` | `string` | Name of protocol |
-| `description` | `string` | Description of protocol |
-| `iconUrl` | `string` | Protocol icon |
-| `siteUrl` | `string` | Protocol website |
+| Name           | Type                                      | Description                           |
+| :------------- | :---------------------------------------- | :------------------------------------ |
+| `protocolId`   | `Protocol`                                | Unique protocol id                    |
+| `chainId`      | `Chain`                                   | Chain this adapter is for             |
+| `name`         | `string`                                  | Name of protocol                      |
+| `description`  | `string`                                  | Description of protocol               |
+| `iconUrl`      | `string`                                  | Protocol icon                         |
+| `siteUrl`      | `string`                                  | Protocol website                      |
 | `positionType` | [`PositionType`](adapter.md#positiontype) | Type of position One adapter per type |
 
 #### Defined in
@@ -180,11 +180,11 @@ ___
 
 #### Type declaration
 
-| Name | Type |
-| :------ | :------ |
-| `Protocol` | ``"protocol"`` |
-| `Reward` | ``"claimable"`` |
-| `Underlying` | ``"underlying"`` |
+| Name         | Type           |
+| :----------- | :------------- |
+| `Protocol`   | `"protocol"`   |
+| `Reward`     | `"claimable"`  |
+| `Underlying` | `"underlying"` |
 
 #### Defined in
 
@@ -192,7 +192,7 @@ ___
 
 [adapter.ts:11](https://github.com/consensys-vertical-apps/mmi-defi-adapters/blob/main/src/types/adapter.ts#L11)
 
-___
+---
 
 ### PositionType
 
@@ -200,12 +200,12 @@ ___
 
 #### Type declaration
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `Supply` | ``"supply"`` | Liquidity position e.g. a dex pool |
-| `Lend` | ``"lend"`` | Providing liquidity to a lending and borrow protocol |
-| `Borrow` | ``"borrow"`` | Getting a loan from a lending and borrow protocol |
-| `Staked` | ``"stake"`` | Staking a token e.g. staking eth or staking an lp token |
+| Name     | Type       | Description                                             |
+| :------- | :--------- | :------------------------------------------------------ |
+| `Supply` | `"supply"` | Liquidity position e.g. a dex pool                      |
+| `Lend`   | `"lend"`   | Providing liquidity to a lending and borrow protocol    |
+| `Borrow` | `"borrow"` | Getting a loan from a lending and borrow protocol       |
+| `Staked` | `"stake"`  | Staking a token e.g. staking eth or staking an lp token |
 
 #### Defined in
 

--- a/src/adapters/example/products/example-product/exampleProductAdapter.ts
+++ b/src/adapters/example/products/example-product/exampleProductAdapter.ts
@@ -1,5 +1,5 @@
-import { ethers } from 'ethers'
 import { Chain } from '../../../../core/constants/chains'
+import { CustomJsonRpcProvider } from '../../../../core/utils/customJsonRpcProvider'
 import {
   GetAprInput,
   GetApyInput,
@@ -31,7 +31,7 @@ export class ExampleProductAdapter implements IProtocolAdapter {
 
   product = 'example-pool'
 
-  private provider: ethers.JsonRpcProvider
+  private provider: CustomJsonRpcProvider
 
   constructor({ provider, chainId, protocolId }: ProtocolAdapterParams) {
     this.provider = provider

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -28,6 +28,7 @@ export const supportedProtocols: Record<
   [Protocol.Example]: {
     [Chain.Ethereum]: [ExampleProductAdapter],
   },
+
   [Protocol.AaveV2]: {
     [Chain.Ethereum]: [
       AaveV2ATokenPoolAdapter,
@@ -45,6 +46,7 @@ export const supportedProtocols: Record<
       AaveV2VariableDebtTokenPoolAdapter,
     ],
   },
+
   [Protocol.AaveV3]: {
     [Chain.Ethereum]: [
       AaveV3ATokenPoolAdapter,
@@ -82,6 +84,7 @@ export const supportedProtocols: Record<
       AaveV3VariableDebtTokenPoolAdapter,
     ],
   },
+
   [Protocol.UniswapV3]: {
     [Chain.Ethereum]: [UniswapV3PoolAdapter],
     [Chain.Arbitrum]: [UniswapV3PoolAdapter],

--- a/src/adapters/integration.test.ts
+++ b/src/adapters/integration.test.ts
@@ -18,7 +18,6 @@ import { testCases as aaveV2TestCases } from './aave-v2/tests/testCases'
 import { testCases as exampleTestCases } from './example/tests/testCases'
 import { Protocol } from './protocols'
 import { testCases as stargateTestCases } from './stargate/tests/testCases'
-import { testCases as testJPTestCases } from './test-jp/tests/testCases'
 import { testCases as uniswapV3TestCases } from './uniswap-v3/tests/testCases'
 
 const TEST_TIMEOUT = 10000
@@ -30,9 +29,6 @@ function runAllTests() {
   runProtocolTests(Protocol.Stargate, stargateTestCases)
   runProtocolTests(Protocol.AaveV2, aaveV2TestCases)
   runProtocolTests(Protocol.UniswapV3, uniswapV3TestCases)
-  runProtocolTests(Protocol.TestJP, testJPTestCases)
-  runProtocolTests(Protocol.TestJP, testJPTestCases)
-  runProtocolTests(Protocol.TestJP, testJPTestCases)
 }
 
 function runProtocolTests(protocolId: Protocol, testCases: TestCase[]) {

--- a/src/adapters/integration.test.ts
+++ b/src/adapters/integration.test.ts
@@ -18,6 +18,7 @@ import { testCases as aaveV2TestCases } from './aave-v2/tests/testCases'
 import { testCases as exampleTestCases } from './example/tests/testCases'
 import { Protocol } from './protocols'
 import { testCases as stargateTestCases } from './stargate/tests/testCases'
+import { testCases as testJPTestCases } from './test-jp/tests/testCases'
 import { testCases as uniswapV3TestCases } from './uniswap-v3/tests/testCases'
 
 const TEST_TIMEOUT = 10000
@@ -29,6 +30,9 @@ function runAllTests() {
   runProtocolTests(Protocol.Stargate, stargateTestCases)
   runProtocolTests(Protocol.AaveV2, aaveV2TestCases)
   runProtocolTests(Protocol.UniswapV3, uniswapV3TestCases)
+  runProtocolTests(Protocol.TestJP, testJPTestCases)
+  runProtocolTests(Protocol.TestJP, testJPTestCases)
+  runProtocolTests(Protocol.TestJP, testJPTestCases)
 }
 
 function runProtocolTests(protocolId: Protocol, testCases: TestCase[]) {

--- a/src/adapters/stargate/products/vesting/stargateVestingAdapter.ts
+++ b/src/adapters/stargate/products/vesting/stargateVestingAdapter.ts
@@ -1,10 +1,10 @@
-import type { ethers } from 'ethers'
 import { Chain } from '../../../../core/constants/chains'
 import {
   CacheToFile,
   IMetadataBuilder,
 } from '../../../../core/decorators/cacheToFile'
 import { NotImplementedError } from '../../../../core/errors/errors'
+import { CustomJsonRpcProvider } from '../../../../core/utils/customJsonRpcProvider'
 import { getTokenMetadata } from '../../../../core/utils/getTokenMetadata'
 import {
   GetAprInput,
@@ -42,7 +42,7 @@ export class StargateVestingAdapter
   protocolId: Protocol
   chainId: Chain
 
-  private provider: ethers.JsonRpcProvider
+  private provider: CustomJsonRpcProvider
 
   constructor({ provider, chainId, protocolId }: ProtocolAdapterParams) {
     this.provider = provider

--- a/src/adapters/uniswap-v3/products/pool/uniswapV3PoolAdapter.ts
+++ b/src/adapters/uniswap-v3/products/pool/uniswapV3PoolAdapter.ts
@@ -1,7 +1,8 @@
-import { ethers, formatUnits } from 'ethers'
+import { formatUnits } from 'ethers'
 import { Chain } from '../../../../core/constants/chains'
 import { NotImplementedError } from '../../../../core/errors/errors'
 import { aggregateTrades } from '../../../../core/utils/aggregateTrades'
+import { CustomJsonRpcProvider } from '../../../../core/utils/customJsonRpcProvider'
 import { filterMapAsync } from '../../../../core/utils/filters'
 import { getTokenMetadata } from '../../../../core/utils/getTokenMetadata'
 import { formatProtocolTokenArrayToMap } from '../../../../core/utils/protocolTokenToMap'
@@ -71,7 +72,7 @@ export class UniswapV3PoolAdapter implements IProtocolAdapter {
   protocolId: Protocol
   chainId: Chain
 
-  private provider: ethers.JsonRpcProvider
+  private provider: CustomJsonRpcProvider
 
   constructor({ provider, chainId, protocolId }: ProtocolAdapterParams) {
     this.provider = provider

--- a/src/core/adapters/SimplePoolAdapter.ts
+++ b/src/core/adapters/SimplePoolAdapter.ts
@@ -1,4 +1,3 @@
-import type { ethers } from 'ethers'
 import { formatUnits } from 'ethers'
 import { Protocol } from '../../adapters/protocols'
 import { Erc20__factory } from '../../contracts'
@@ -33,6 +32,7 @@ import { IProtocolAdapter } from '../../types/IProtocolAdapter'
 import { Chain } from '../constants/chains'
 import { ZERO_ADDRESS } from '../constants/ZERO_ADDRESS'
 import { aggregateTrades } from '../utils/aggregateTrades'
+import { CustomJsonRpcProvider } from '../utils/customJsonRpcProvider'
 import { getBalances } from '../utils/getBalances'
 import { formatProtocolTokenArrayToMap } from '../utils/protocolTokenToMap'
 
@@ -40,7 +40,7 @@ export abstract class SimplePoolAdapter implements IProtocolAdapter {
   chainId: Chain
   protocolId: Protocol
 
-  protected provider: ethers.JsonRpcProvider
+  protected provider: CustomJsonRpcProvider
 
   constructor({ provider, chainId, protocolId }: ProtocolAdapterParams) {
     this.provider = provider

--- a/src/core/constants/AVERAGE_BLOCKS_PER_10_MINS.ts
+++ b/src/core/constants/AVERAGE_BLOCKS_PER_10_MINS.ts
@@ -1,0 +1,11 @@
+import { AVERAGE_BLOCKS_PER_DAY } from './AVERAGE_BLOCKS_PER_DAY'
+import { Chain } from './chains'
+
+export const AVERAGE_BLOCKS_PER_10_MINUTES: Record<Chain, number> =
+  Object.entries(AVERAGE_BLOCKS_PER_DAY).reduce(
+    (acc, [chain, blocksPerDay]) => {
+      acc[chain as unknown as Chain] = (blocksPerDay * 10) / (24 * 60)
+      return acc
+    },
+    {} as Record<Chain, number>,
+  )

--- a/src/core/utils/CustomMulticallJsonRpcProvider.test.ts
+++ b/src/core/utils/CustomMulticallJsonRpcProvider.test.ts
@@ -1,4 +1,4 @@
-import { CustomMulticallJsonRpcProvider } from './CustomMulticallJsonRpcProvider'
+import { CustomMulticallJsonRpcProvider } from './customMulticallJsonRpcProvider'
 import { MulticallQueue } from './multicall'
 
 describe('CustomMulticallJsonRpcProvider', () => {
@@ -10,7 +10,7 @@ describe('CustomMulticallJsonRpcProvider', () => {
 
       const provider = new CustomMulticallJsonRpcProvider({
         url: 'www.oioi.com',
-        network: 1,
+        chainId: 1,
         multicallQueue,
       })
 
@@ -23,7 +23,7 @@ describe('CustomMulticallJsonRpcProvider', () => {
     it('sends normal eth_call', async () => {
       const provider = new CustomMulticallJsonRpcProvider({
         url: 'www.oioi.com',
-        network: 1,
+        chainId: 1,
         multicallQueue: {} as MulticallQueue,
       })
 

--- a/src/core/utils/CustomMulticallJsonRpcProvider.test.ts
+++ b/src/core/utils/CustomMulticallJsonRpcProvider.test.ts
@@ -1,4 +1,4 @@
-import { CustomMulticallJsonRpcProvider } from './customMulticallJsonRpcProvider'
+import { CustomMulticallJsonRpcProvider } from './CustomMulticallJsonRpcProvider'
 import { MulticallQueue } from './multicall'
 
 describe('CustomMulticallJsonRpcProvider', () => {

--- a/src/core/utils/CustomMulticallJsonRpcProvider.ts
+++ b/src/core/utils/CustomMulticallJsonRpcProvider.ts
@@ -1,19 +1,21 @@
-import { JsonRpcProvider, Networkish, TransactionRequest } from 'ethers'
+import { TransactionRequest } from 'ethers'
+import { Chain } from '../constants/chains'
+import { CustomJsonRpcProvider } from './customJsonRpcProvider'
 import { logger } from './logger'
 import { MulticallQueue } from './multicall'
 
-export class CustomMulticallJsonRpcProvider extends JsonRpcProvider {
+export class CustomMulticallJsonRpcProvider extends CustomJsonRpcProvider {
   private multicallQueue: MulticallQueue
   constructor({
     url,
-    network,
+    chainId,
     multicallQueue,
   }: {
     url: string
-    network: Networkish
+    chainId: Chain
     multicallQueue: MulticallQueue
   }) {
-    super(url, network)
+    super({ url, chainId })
     this.multicallQueue = multicallQueue
   }
 

--- a/src/core/utils/chainProviders.ts
+++ b/src/core/utils/chainProviders.ts
@@ -3,7 +3,7 @@ import { Multicall__factory } from '../../contracts'
 import { Chain } from '../constants/chains'
 import { MULTICALL_ADDRESS } from '../constants/MULTICALL_ADDRESS'
 import { CustomJsonRpcProvider } from './customJsonRpcProvider'
-import { CustomMulticallJsonRpcProvider } from './customMulticallJsonRpcProvider'
+import { CustomMulticallJsonRpcProvider } from './CustomMulticallJsonRpcProvider'
 import { logger } from './logger'
 import { MulticallQueue } from './multicall'
 

--- a/src/core/utils/chainProviders.ts
+++ b/src/core/utils/chainProviders.ts
@@ -1,8 +1,9 @@
-import { Network, ethers } from 'ethers'
+import { Network } from 'ethers'
 import { Multicall__factory } from '../../contracts'
 import { Chain } from '../constants/chains'
 import { MULTICALL_ADDRESS } from '../constants/MULTICALL_ADDRESS'
-import { CustomMulticallJsonRpcProvider } from './CustomMulticallJsonRpcProvider'
+import { CustomJsonRpcProvider } from './customJsonRpcProvider'
+import { CustomMulticallJsonRpcProvider } from './customMulticallJsonRpcProvider'
 import { logger } from './logger'
 import { MulticallQueue } from './multicall'
 
@@ -19,14 +20,25 @@ const provider = ({
 
   if (!enableMulticallQueue) {
     logger.debug({ chainId }, `Using standard provider`)
-    return new ethers.JsonRpcProvider(url, chainId, {
-      staticNetwork: Network.from(chainId),
+
+    return new CustomJsonRpcProvider({
+      url,
+      chainId,
+      options: {
+        staticNetwork: Network.from(chainId),
+      },
     })
   }
 
   logger.debug({ chainId }, 'Using multicall queue provider')
 
-  const provider = new ethers.JsonRpcProvider(url, chainId)
+  const provider = new CustomJsonRpcProvider({
+    url,
+    chainId,
+    options: {
+      staticNetwork: Network.from(chainId),
+    },
+  })
 
   // deployed on 100+ chains at address
   // https://www.multicall3.com/deployments
@@ -43,14 +55,14 @@ const provider = ({
 
   return new CustomMulticallJsonRpcProvider({
     url,
-    network: chainId,
+    chainId: chainId,
     multicallQueue,
   })
 }
 
 const enableMulticallQueue = process.env.ENABLE_MULTICALL_QUEUE === 'true'
 
-export const chainProviders: Record<Chain, ethers.JsonRpcProvider | undefined> =
+export const chainProviders: Record<Chain, CustomJsonRpcProvider | undefined> =
   {
     [Chain.Ethereum]: provider({
       url: process.env.ETHEREUM_PROVIDER_URL,

--- a/src/core/utils/customJsonRpcProvider.ts
+++ b/src/core/utils/customJsonRpcProvider.ts
@@ -1,0 +1,33 @@
+import { JsonRpcApiProviderOptions, JsonRpcProvider } from 'ethers'
+import { AVERAGE_BLOCKS_PER_10_MINUTES } from '../constants/AVERAGE_BLOCKS_PER_10_MINS'
+import { Chain } from '../constants/chains'
+
+export class CustomJsonRpcProvider extends JsonRpcProvider {
+  chainId: Chain
+  constructor({
+    url,
+    chainId,
+    options,
+  }: {
+    url: string
+
+    options?: JsonRpcApiProviderOptions
+    chainId: Chain
+  }) {
+    super(url, chainId, options)
+    this.chainId = chainId
+  }
+
+  /**
+   * Returns 10 min old blockNumber to ensure data has propagated across nodes
+   * Getting logs close to head has issues
+   * @returns
+   */
+  async getStableBlockNumber(): Promise<number> {
+    const currentBlockNumber = await this.getBlockNumber()
+
+    const blockNumberTenMinsAgo =
+      currentBlockNumber - (AVERAGE_BLOCKS_PER_10_MINUTES[this.chainId] ?? 0) // default to 0 to avoid failures
+    return blockNumberTenMinsAgo
+  }
+}

--- a/src/core/utils/getAddressesBalances.ts
+++ b/src/core/utils/getAddressesBalances.ts
@@ -1,6 +1,6 @@
-import type { ethers } from 'ethers'
 import { BalanceChecker__factory } from '../../contracts'
 import { Chain } from '../constants/chains'
+import { CustomJsonRpcProvider } from './customJsonRpcProvider'
 
 type AddressBalanceMap = {
   [address: string]: BalanceMap
@@ -31,7 +31,7 @@ export async function getAddressesBalances({
   blockNumber,
 }: {
   chainId: Chain
-  provider: ethers.JsonRpcProvider
+  provider: CustomJsonRpcProvider
   addresses: string[]
   tokens: string[]
   blockNumber?: number

--- a/src/core/utils/getTokenMetadata.ts
+++ b/src/core/utils/getTokenMetadata.ts
@@ -5,6 +5,7 @@ import { Chain } from '../constants/chains'
 import TOKEN_METADATA_ARBITRUM from '../metadata/token-metadata-arbitrum.json'
 import TOKEN_METADATA_ETHEREUM from '../metadata/token-metadata-ethereum.json'
 import { chainProviders } from './chainProviders'
+import { CustomJsonRpcProvider } from './customJsonRpcProvider'
 import { extractErrorMessage } from './extractErrorMessage'
 import { logger } from './logger'
 
@@ -83,7 +84,7 @@ async function getOnChainTokenMetadata(
 
 async function fetchStringTokenData(
   tokenContract: Erc20,
-  provider: ethers.JsonRpcProvider,
+  provider: CustomJsonRpcProvider,
   functionName: 'name' | 'symbol',
 ): Promise<string> {
   try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-import { ethers } from 'ethers'
 import { supportedProtocols } from './adapters'
 import { Protocol } from './adapters/protocols'
 import { AVERAGE_BLOCKS_PER_DAY } from './core/constants/AVERAGE_BLOCKS_PER_DAY'
@@ -6,6 +5,7 @@ import { Chain, ChainName } from './core/constants/chains'
 import { TimePeriod } from './core/constants/timePeriod'
 import { ProviderMissingError } from './core/errors/errors'
 import { chainProviders } from './core/utils/chainProviders'
+import { CustomJsonRpcProvider } from './core/utils/customJsonRpcProvider'
 import {
   enrichPositionBalance,
   enrichProfitsWithRange,
@@ -85,11 +85,11 @@ export async function getProfits({
 }): Promise<DefiProfitsResponse[]> {
   const runner = async (
     adapter: IProtocolAdapter,
-    provider: ethers.JsonRpcProvider,
+    provider: CustomJsonRpcProvider,
   ) => {
     const toBlock =
       toBlockNumbersOverride?.[adapter.chainId] ??
-      (await provider.getBlockNumber())
+      (await provider.getStableBlockNumber())
     const fromBlock =
       toBlock - AVERAGE_BLOCKS_PER_DAY[adapter.chainId] * timePeriod
     const profits = await adapter.getProfits({
@@ -358,7 +358,7 @@ async function runForAllProtocolsAndChains<ReturnType extends object>({
 }: {
   runner: (
     adapter: IProtocolAdapter,
-    provider: ethers.JsonRpcProvider,
+    provider: CustomJsonRpcProvider,
   ) => ReturnType
   filterProtocolIds?: Protocol[]
   filterChainIds?: Chain[]
@@ -402,10 +402,10 @@ async function runForAllProtocolsAndChains<ReturnType extends object>({
 
 async function runTaskForAdapter<ReturnType>(
   adapter: IProtocolAdapter,
-  provider: ethers.JsonRpcProvider,
+  provider: CustomJsonRpcProvider,
   runner: (
     adapter: IProtocolAdapter,
-    provider: ethers.JsonRpcProvider,
+    provider: CustomJsonRpcProvider,
   ) => ReturnType,
 ): Promise<AdapterResponse<Awaited<ReturnType>>> {
   const protocolDetails = adapter.getProtocolDetails()

--- a/src/scripts/buildSnapshots.ts
+++ b/src/scripts/buildSnapshots.ts
@@ -49,7 +49,7 @@ export function buildSnapshots(program: Command) {
             switch (testCase.method) {
               case 'positions': {
                 const blockNumber =
-                  testCase.blockNumber ?? (await getLatestBlock(chainId))
+                  testCase.blockNumber ?? (await getLatestStableBlock(chainId))
 
                 return {
                   blockNumber,
@@ -66,7 +66,7 @@ export function buildSnapshots(program: Command) {
 
               case 'profits': {
                 const blockNumber =
-                  testCase.blockNumber ?? (await getLatestBlock(chainId))
+                  testCase.blockNumber ?? (await getLatestStableBlock(chainId))
 
                 return {
                   blockNumber,
@@ -103,7 +103,7 @@ export function buildSnapshots(program: Command) {
 
               case 'prices': {
                 const blockNumber =
-                  testCase.blockNumber ?? (await getLatestBlock(chainId))
+                  testCase.blockNumber ?? (await getLatestStableBlock(chainId))
 
                 return {
                   blockNumber,
@@ -119,7 +119,7 @@ export function buildSnapshots(program: Command) {
 
               case 'tvl': {
                 const blockNumber =
-                  testCase.blockNumber ?? (await getLatestBlock(chainId))
+                  testCase.blockNumber ?? (await getLatestStableBlock(chainId))
 
                 return {
                   blockNumber,
@@ -135,7 +135,7 @@ export function buildSnapshots(program: Command) {
 
               case 'apy': {
                 const blockNumber =
-                  testCase.blockNumber ?? (await getLatestBlock(chainId))
+                  testCase.blockNumber ?? (await getLatestStableBlock(chainId))
 
                 return {
                   blockNumber,
@@ -151,7 +151,7 @@ export function buildSnapshots(program: Command) {
 
               case 'apr': {
                 const blockNumber =
-                  testCase.blockNumber ?? (await getLatestBlock(chainId))
+                  testCase.blockNumber ?? (await getLatestStableBlock(chainId))
 
                 return {
                   blockNumber,
@@ -185,12 +185,12 @@ export function buildSnapshots(program: Command) {
     })
 }
 
-async function getLatestBlock(chainId: Chain): Promise<number> {
+async function getLatestStableBlock(chainId: Chain): Promise<number> {
   const provider = chainProviders[chainId]
 
   if (!provider) {
     throw new ProviderMissingError(chainId)
   }
 
-  return provider.getBlockNumber()
+  return provider.getStableBlockNumber()
 }

--- a/src/scripts/templates/defaultAdapter.ts
+++ b/src/scripts/templates/defaultAdapter.ts
@@ -3,13 +3,13 @@ export function defaultAdapterTemplate(
   adapterClassName: string,
   productId: string,
 ) {
-  return `import { ethers } from 'ethers'
-  import { Chain } from '../../../../core/constants/chains'
+  return `import { Chain } from '../../../../core/constants/chains'
   import {
     IMetadataBuilder,
     CacheToFile,
   } from '../../../../core/decorators/cacheToFile'
   import { NotImplementedError } from '../../../../core/errors/errors'
+  import { CustomJsonRpcProvider } from '../../../../core/utils/customJsonRpcProvider'
   import {
     ProtocolAdapterParams,
     ProtocolDetails,
@@ -40,7 +40,7 @@ export function defaultAdapterTemplate(
     protocolId: Protocol
     chainId: Chain
   
-    private provider: ethers.JsonRpcProvider
+    private provider: CustomJsonRpcProvider
   
     constructor({ provider, chainId, protocolId }: ProtocolAdapterParams) {
       this.provider = provider

--- a/src/types/adapter.ts
+++ b/src/types/adapter.ts
@@ -1,6 +1,6 @@
-import { ethers } from 'ethers'
 import { Protocol } from '../adapters/protocols'
 import { Chain } from '../core/constants/chains'
+import { CustomJsonRpcProvider } from '../core/utils/customJsonRpcProvider'
 import { Erc20Metadata } from './erc20Metadata'
 
 export const TokenType = {
@@ -35,7 +35,7 @@ export const PositionType = {
 export type PositionType = (typeof PositionType)[keyof typeof PositionType]
 
 export type GetBalancesInput = GetPositionsInput & {
-  provider: ethers.JsonRpcProvider
+  provider: CustomJsonRpcProvider
   chainId: Chain
   tokens: Erc20Metadata[]
 }
@@ -355,7 +355,7 @@ export interface CalculationData {
 }
 
 export interface ProtocolAdapterParams {
-  provider: ethers.JsonRpcProvider
+  provider: CustomJsonRpcProvider
   chainId: Chain
   protocolId: Protocol
 }


### PR DESCRIPTION
Extends the ethers.jsonRpcProvider and adds an additional method called getStableBlock.

 Returns 10 min old blockNumber to ensure data has propagated across nodes
 Getting logs close to head has issues