### PR TITLE
feat: missing profits

### DIFF
--- a/src/adapters/aave-v2/common/aaveBasePoolAdapter.ts
+++ b/src/adapters/aave-v2/common/aaveBasePoolAdapter.ts
@@ -225,7 +225,15 @@ export abstract class AaveBasePoolAdapter
     const poolMetadata = (await this.buildMetadata())[protocolTokenAddress]
 
     if (!poolMetadata) {
-      logger.error({ protocolTokenAddress }, 'Protocol token pool not found')
+      logger.error(
+        {
+          protocolTokenAddress,
+          protocol: this.protocolId,
+          chainId: this.chainId,
+          product: this.productId,
+        },
+        'Protocol token pool not found',
+      )
       throw new Error('Protocol token pool not found')
     }
 

--- a/src/adapters/carbon-defi/tests/snapshots/ethereum.profits.profits-3.json
+++ b/src/adapters/carbon-defi/tests/snapshots/ethereum.profits.profits-3.json
@@ -1,0 +1,1950 @@
+{
+  "blockNumber": 19184953,
+  "snapshot": [
+    {
+      "protocolId": "carbon-defi",
+      "name": "CarbonDeFi",
+      "description": "CarbonDeFi adapter for strategy balances",
+      "siteUrl": "https://carbondefi.xyz",
+      "iconUrl": "https://app.carbondefi.xyz/favicon.ico",
+      "positionType": "supply",
+      "chainId": 1,
+      "productId": "strategies",
+      "success": true,
+      "tokens": [
+        {
+          "address": "0x3660F04B79751e31128f6378eAC70807e38f554E",
+          "name": "ETH / stETH",
+          "symbol": "ETH / stETH",
+          "decimals": 18,
+          "tokenId": "680564733841876926926749214863536422914",
+          "type": "protocol",
+          "profit": 0,
+          "performance": 0,
+          "calculationData": {
+            "withdrawals": 0,
+            "deposits": 0,
+            "startPositionValue": 0,
+            "endPositionValue": 0
+          },
+          "rawValues": {
+            "rawEndPositionValues": [
+              {
+                "address": "0x3660F04B79751e31128f6378eAC70807e38f554E",
+                "name": "ETH / stETH",
+                "symbol": "ETH / stETH",
+                "decimals": 18,
+                "type": "protocol",
+                "tokenId": "680564733841876926926749214863536422914",
+                "balanceRaw": "1000000000000000000n",
+                "tokens": [
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "0n",
+                    "address": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+                    "name": "Ethereum",
+                    "symbol": "ETH",
+                    "decimals": 18,
+                    "balance": 0,
+                    "price": 2421.72692,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/info/logo.png"
+                  },
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "0n",
+                    "address": "0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84",
+                    "name": "Liquid staked Ether 2.0",
+                    "symbol": "stETH",
+                    "decimals": 18,
+                    "tokens": [
+                      {
+                        "address": "0x0000000000000000000000000000000000000000",
+                        "name": "Ethereum",
+                        "symbol": "ETH",
+                        "decimals": 18,
+                        "type": "underlying",
+                        "balanceRaw": "0n",
+                        "balance": 0,
+                        "price": 2421.72692,
+                        "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/info/logo.png"
+                      }
+                    ],
+                    "balance": 0,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84/logo.png"
+                  }
+                ],
+                "balance": 1
+              },
+              {
+                "address": "0x3660F04B79751e31128f6378eAC70807e38f554E",
+                "name": "USDC / USDT",
+                "symbol": "USDC / USDT",
+                "decimals": 18,
+                "type": "protocol",
+                "tokenId": "1020847100762815390390123822295304634371",
+                "balanceRaw": "1000000000000000000n",
+                "tokens": [
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "0n",
+                    "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                    "name": "USD Coin",
+                    "symbol": "USDC",
+                    "decimals": 6,
+                    "balance": 0,
+                    "price": 0.9974964416136795,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
+                  },
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "100256523n",
+                    "address": "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+                    "name": "Tether USD",
+                    "symbol": "USDT",
+                    "decimals": 6,
+                    "balance": 100.256523,
+                    "price": 0.9974515833602204,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdAC17F958D2ee523a2206206994597C13D831ec7/logo.png"
+                  }
+                ],
+                "balance": 1
+              },
+              {
+                "address": "0x3660F04B79751e31128f6378eAC70807e38f554E",
+                "name": "USDC / DAI",
+                "symbol": "USDC / DAI",
+                "decimals": 18,
+                "type": "protocol",
+                "tokenId": "1361129467683753853853498429727072845828",
+                "balanceRaw": "1000000000000000000n",
+                "tokens": [
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "50000000n",
+                    "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                    "name": "USD Coin",
+                    "symbol": "USDC",
+                    "decimals": 6,
+                    "balance": 50,
+                    "price": 0.9974964416136795,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
+                  },
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "30000000000064988n",
+                    "address": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+                    "name": "Dai Stablecoin",
+                    "symbol": "DAI",
+                    "decimals": 18,
+                    "balance": 0.03000000000006499,
+                    "price": 0.9984701441151138,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png"
+                  }
+                ],
+                "balance": 1
+              },
+              {
+                "address": "0x3660F04B79751e31128f6378eAC70807e38f554E",
+                "name": "DAI / USDT",
+                "symbol": "DAI / USDT",
+                "decimals": 18,
+                "type": "protocol",
+                "tokenId": "2041694201525630780780247644590609268742",
+                "balanceRaw": "1000000000000000000n",
+                "tokens": [
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "5820057695805493n",
+                    "address": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+                    "name": "Dai Stablecoin",
+                    "symbol": "DAI",
+                    "decimals": 18,
+                    "balance": 0.005820057695805493,
+                    "price": 0.9984701441151138,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png"
+                  },
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "40070413n",
+                    "address": "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+                    "name": "Tether USD",
+                    "symbol": "USDT",
+                    "decimals": 6,
+                    "balance": 40.070413,
+                    "price": 0.9974515833602204,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdAC17F958D2ee523a2206206994597C13D831ec7/logo.png"
+                  }
+                ],
+                "balance": 1
+              },
+              {
+                "address": "0x3660F04B79751e31128f6378eAC70807e38f554E",
+                "name": "BBS / USDC",
+                "symbol": "BBS / USDC",
+                "decimals": 18,
+                "type": "protocol",
+                "tokenId": "32667107224410092492483962313449748300520",
+                "balanceRaw": "1000000000000000000n",
+                "tokens": [
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "4796297636542810062982n",
+                    "address": "0xFe459828c90c0BA4bC8b42F5C5D44F316700B430",
+                    "name": "BBS",
+                    "symbol": "BBS",
+                    "decimals": 18,
+                    "balance": 4796.29763654281,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xFe459828c90c0BA4bC8b42F5C5D44F316700B430/logo.png"
+                  },
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "0n",
+                    "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                    "name": "USD Coin",
+                    "symbol": "USDC",
+                    "decimals": 6,
+                    "balance": 0,
+                    "price": 0.9974964416136795,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
+                  }
+                ],
+                "balance": 1
+              }
+            ],
+            "rawStartPositionValues": [
+              {
+                "address": "0x3660F04B79751e31128f6378eAC70807e38f554E",
+                "name": "ETH / stETH",
+                "symbol": "ETH / stETH",
+                "decimals": 18,
+                "type": "protocol",
+                "tokenId": "680564733841876926926749214863536422914",
+                "balanceRaw": "1000000000000000000n",
+                "tokens": [
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "0n",
+                    "address": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+                    "name": "Ethereum",
+                    "symbol": "ETH",
+                    "decimals": 18,
+                    "balance": 0,
+                    "price": 2289.69086146,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/info/logo.png"
+                  },
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "0n",
+                    "address": "0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84",
+                    "name": "Liquid staked Ether 2.0",
+                    "symbol": "stETH",
+                    "decimals": 18,
+                    "tokens": [
+                      {
+                        "address": "0x0000000000000000000000000000000000000000",
+                        "name": "Ethereum",
+                        "symbol": "ETH",
+                        "decimals": 18,
+                        "type": "underlying",
+                        "balanceRaw": "0n",
+                        "balance": 0,
+                        "price": 2289.69086146,
+                        "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/info/logo.png"
+                      }
+                    ],
+                    "balance": 0,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84/logo.png"
+                  }
+                ],
+                "balance": 1
+              },
+              {
+                "address": "0x3660F04B79751e31128f6378eAC70807e38f554E",
+                "name": "USDC / USDT",
+                "symbol": "USDC / USDT",
+                "decimals": 18,
+                "type": "protocol",
+                "tokenId": "1020847100762815390390123822295304634371",
+                "balanceRaw": "1000000000000000000n",
+                "tokens": [
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "0n",
+                    "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                    "name": "USD Coin",
+                    "symbol": "USDC",
+                    "decimals": 6,
+                    "balance": 0,
+                    "price": 1.003138130924194,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
+                  },
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "100256523n",
+                    "address": "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+                    "name": "Tether USD",
+                    "symbol": "USDT",
+                    "decimals": 6,
+                    "balance": 100.256523,
+                    "price": 1.0027057369860566,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdAC17F958D2ee523a2206206994597C13D831ec7/logo.png"
+                  }
+                ],
+                "balance": 1
+              },
+              {
+                "address": "0x3660F04B79751e31128f6378eAC70807e38f554E",
+                "name": "USDC / DAI",
+                "symbol": "USDC / DAI",
+                "decimals": 18,
+                "type": "protocol",
+                "tokenId": "1361129467683753853853498429727072845828",
+                "balanceRaw": "1000000000000000000n",
+                "tokens": [
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "50000000n",
+                    "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                    "name": "USD Coin",
+                    "symbol": "USDC",
+                    "decimals": 6,
+                    "balance": 50,
+                    "price": 1.003138130924194,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
+                  },
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "30000000000064988n",
+                    "address": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+                    "name": "Dai Stablecoin",
+                    "symbol": "DAI",
+                    "decimals": 18,
+                    "balance": 0.03000000000006499,
+                    "price": 1.0021616484031988,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png"
+                  }
+                ],
+                "balance": 1
+              },
+              {
+                "address": "0x3660F04B79751e31128f6378eAC70807e38f554E",
+                "name": "DAI / USDT",
+                "symbol": "DAI / USDT",
+                "decimals": 18,
+                "type": "protocol",
+                "tokenId": "2041694201525630780780247644590609268742",
+                "balanceRaw": "1000000000000000000n",
+                "tokens": [
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "5820057695805493n",
+                    "address": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+                    "name": "Dai Stablecoin",
+                    "symbol": "DAI",
+                    "decimals": 18,
+                    "balance": 0.005820057695805493,
+                    "price": 1.0021616484031988,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png"
+                  },
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "40070413n",
+                    "address": "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+                    "name": "Tether USD",
+                    "symbol": "USDT",
+                    "decimals": 6,
+                    "balance": 40.070413,
+                    "price": 1.0027057369860566,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdAC17F958D2ee523a2206206994597C13D831ec7/logo.png"
+                  }
+                ],
+                "balance": 1
+              },
+              {
+                "address": "0x3660F04B79751e31128f6378eAC70807e38f554E",
+                "name": "BBS / USDC",
+                "symbol": "BBS / USDC",
+                "decimals": 18,
+                "type": "protocol",
+                "tokenId": "32667107224410092492483962313449748300520",
+                "balanceRaw": "1000000000000000000n",
+                "tokens": [
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "4796297636542810062982n",
+                    "address": "0xFe459828c90c0BA4bC8b42F5C5D44F316700B430",
+                    "name": "BBS",
+                    "symbol": "BBS",
+                    "decimals": 18,
+                    "balance": 4796.29763654281,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xFe459828c90c0BA4bC8b42F5C5D44F316700B430/logo.png"
+                  },
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "0n",
+                    "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                    "name": "USD Coin",
+                    "symbol": "USDC",
+                    "decimals": 6,
+                    "balance": 0,
+                    "price": 1.003138130924194,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
+                  }
+                ],
+                "balance": 1
+              }
+            ],
+            "rawWithdrawals": [],
+            "rawDeposits": []
+          }
+        },
+        {
+          "address": "0x3660F04B79751e31128f6378eAC70807e38f554E",
+          "name": "USDC / USDT",
+          "symbol": "USDC / USDT",
+          "decimals": 18,
+          "tokenId": "1020847100762815390390123822295304634371",
+          "type": "protocol",
+          "profit": -0.5267631738341834,
+          "performance": -0.00523997562996819,
+          "calculationData": {
+            "withdrawals": 0,
+            "deposits": 0,
+            "startPositionValue": 100.52779078237454,
+            "endPositionValue": 100.00102760854035
+          },
+          "rawValues": {
+            "rawEndPositionValues": [
+              {
+                "address": "0x3660F04B79751e31128f6378eAC70807e38f554E",
+                "name": "ETH / stETH",
+                "symbol": "ETH / stETH",
+                "decimals": 18,
+                "type": "protocol",
+                "tokenId": "680564733841876926926749214863536422914",
+                "balanceRaw": "1000000000000000000n",
+                "tokens": [
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "0n",
+                    "address": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+                    "name": "Ethereum",
+                    "symbol": "ETH",
+                    "decimals": 18,
+                    "balance": 0,
+                    "price": 2421.72692,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/info/logo.png"
+                  },
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "0n",
+                    "address": "0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84",
+                    "name": "Liquid staked Ether 2.0",
+                    "symbol": "stETH",
+                    "decimals": 18,
+                    "tokens": [
+                      {
+                        "address": "0x0000000000000000000000000000000000000000",
+                        "name": "Ethereum",
+                        "symbol": "ETH",
+                        "decimals": 18,
+                        "type": "underlying",
+                        "balanceRaw": "0n",
+                        "balance": 0,
+                        "price": 2421.72692,
+                        "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/info/logo.png"
+                      }
+                    ],
+                    "balance": 0,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84/logo.png"
+                  }
+                ],
+                "balance": 1
+              },
+              {
+                "address": "0x3660F04B79751e31128f6378eAC70807e38f554E",
+                "name": "USDC / USDT",
+                "symbol": "USDC / USDT",
+                "decimals": 18,
+                "type": "protocol",
+                "tokenId": "1020847100762815390390123822295304634371",
+                "balanceRaw": "1000000000000000000n",
+                "tokens": [
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "0n",
+                    "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                    "name": "USD Coin",
+                    "symbol": "USDC",
+                    "decimals": 6,
+                    "balance": 0,
+                    "price": 0.9974964416136795,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
+                  },
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "100256523n",
+                    "address": "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+                    "name": "Tether USD",
+                    "symbol": "USDT",
+                    "decimals": 6,
+                    "balance": 100.256523,
+                    "price": 0.9974515833602204,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdAC17F958D2ee523a2206206994597C13D831ec7/logo.png"
+                  }
+                ],
+                "balance": 1
+              },
+              {
+                "address": "0x3660F04B79751e31128f6378eAC70807e38f554E",
+                "name": "USDC / DAI",
+                "symbol": "USDC / DAI",
+                "decimals": 18,
+                "type": "protocol",
+                "tokenId": "1361129467683753853853498429727072845828",
+                "balanceRaw": "1000000000000000000n",
+                "tokens": [
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "50000000n",
+                    "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                    "name": "USD Coin",
+                    "symbol": "USDC",
+                    "decimals": 6,
+                    "balance": 50,
+                    "price": 0.9974964416136795,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
+                  },
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "30000000000064988n",
+                    "address": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+                    "name": "Dai Stablecoin",
+                    "symbol": "DAI",
+                    "decimals": 18,
+                    "balance": 0.03000000000006499,
+                    "price": 0.9984701441151138,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png"
+                  }
+                ],
+                "balance": 1
+              },
+              {
+                "address": "0x3660F04B79751e31128f6378eAC70807e38f554E",
+                "name": "DAI / USDT",
+                "symbol": "DAI / USDT",
+                "decimals": 18,
+                "type": "protocol",
+                "tokenId": "2041694201525630780780247644590609268742",
+                "balanceRaw": "1000000000000000000n",
+                "tokens": [
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "5820057695805493n",
+                    "address": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+                    "name": "Dai Stablecoin",
+                    "symbol": "DAI",
+                    "decimals": 18,
+                    "balance": 0.005820057695805493,
+                    "price": 0.9984701441151138,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png"
+                  },
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "40070413n",
+                    "address": "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+                    "name": "Tether USD",
+                    "symbol": "USDT",
+                    "decimals": 6,
+                    "balance": 40.070413,
+                    "price": 0.9974515833602204,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdAC17F958D2ee523a2206206994597C13D831ec7/logo.png"
+                  }
+                ],
+                "balance": 1
+              },
+              {
+                "address": "0x3660F04B79751e31128f6378eAC70807e38f554E",
+                "name": "BBS / USDC",
+                "symbol": "BBS / USDC",
+                "decimals": 18,
+                "type": "protocol",
+                "tokenId": "32667107224410092492483962313449748300520",
+                "balanceRaw": "1000000000000000000n",
+                "tokens": [
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "4796297636542810062982n",
+                    "address": "0xFe459828c90c0BA4bC8b42F5C5D44F316700B430",
+                    "name": "BBS",
+                    "symbol": "BBS",
+                    "decimals": 18,
+                    "balance": 4796.29763654281,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xFe459828c90c0BA4bC8b42F5C5D44F316700B430/logo.png"
+                  },
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "0n",
+                    "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                    "name": "USD Coin",
+                    "symbol": "USDC",
+                    "decimals": 6,
+                    "balance": 0,
+                    "price": 0.9974964416136795,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
+                  }
+                ],
+                "balance": 1
+              }
+            ],
+            "rawStartPositionValues": [
+              {
+                "address": "0x3660F04B79751e31128f6378eAC70807e38f554E",
+                "name": "ETH / stETH",
+                "symbol": "ETH / stETH",
+                "decimals": 18,
+                "type": "protocol",
+                "tokenId": "680564733841876926926749214863536422914",
+                "balanceRaw": "1000000000000000000n",
+                "tokens": [
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "0n",
+                    "address": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+                    "name": "Ethereum",
+                    "symbol": "ETH",
+                    "decimals": 18,
+                    "balance": 0,
+                    "price": 2289.69086146,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/info/logo.png"
+                  },
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "0n",
+                    "address": "0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84",
+                    "name": "Liquid staked Ether 2.0",
+                    "symbol": "stETH",
+                    "decimals": 18,
+                    "tokens": [
+                      {
+                        "address": "0x0000000000000000000000000000000000000000",
+                        "name": "Ethereum",
+                        "symbol": "ETH",
+                        "decimals": 18,
+                        "type": "underlying",
+                        "balanceRaw": "0n",
+                        "balance": 0,
+                        "price": 2289.69086146,
+                        "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/info/logo.png"
+                      }
+                    ],
+                    "balance": 0,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84/logo.png"
+                  }
+                ],
+                "balance": 1
+              },
+              {
+                "address": "0x3660F04B79751e31128f6378eAC70807e38f554E",
+                "name": "USDC / USDT",
+                "symbol": "USDC / USDT",
+                "decimals": 18,
+                "type": "protocol",
+                "tokenId": "1020847100762815390390123822295304634371",
+                "balanceRaw": "1000000000000000000n",
+                "tokens": [
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "0n",
+                    "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                    "name": "USD Coin",
+                    "symbol": "USDC",
+                    "decimals": 6,
+                    "balance": 0,
+                    "price": 1.003138130924194,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
+                  },
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "100256523n",
+                    "address": "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+                    "name": "Tether USD",
+                    "symbol": "USDT",
+                    "decimals": 6,
+                    "balance": 100.256523,
+                    "price": 1.0027057369860566,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdAC17F958D2ee523a2206206994597C13D831ec7/logo.png"
+                  }
+                ],
+                "balance": 1
+              },
+              {
+                "address": "0x3660F04B79751e31128f6378eAC70807e38f554E",
+                "name": "USDC / DAI",
+                "symbol": "USDC / DAI",
+                "decimals": 18,
+                "type": "protocol",
+                "tokenId": "1361129467683753853853498429727072845828",
+                "balanceRaw": "1000000000000000000n",
+                "tokens": [
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "50000000n",
+                    "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                    "name": "USD Coin",
+                    "symbol": "USDC",
+                    "decimals": 6,
+                    "balance": 50,
+                    "price": 1.003138130924194,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
+                  },
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "30000000000064988n",
+                    "address": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+                    "name": "Dai Stablecoin",
+                    "symbol": "DAI",
+                    "decimals": 18,
+                    "balance": 0.03000000000006499,
+                    "price": 1.0021616484031988,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png"
+                  }
+                ],
+                "balance": 1
+              },
+              {
+                "address": "0x3660F04B79751e31128f6378eAC70807e38f554E",
+                "name": "DAI / USDT",
+                "symbol": "DAI / USDT",
+                "decimals": 18,
+                "type": "protocol",
+                "tokenId": "2041694201525630780780247644590609268742",
+                "balanceRaw": "1000000000000000000n",
+                "tokens": [
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "5820057695805493n",
+                    "address": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+                    "name": "Dai Stablecoin",
+                    "symbol": "DAI",
+                    "decimals": 18,
+                    "balance": 0.005820057695805493,
+                    "price": 1.0021616484031988,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png"
+                  },
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "40070413n",
+                    "address": "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+                    "name": "Tether USD",
+                    "symbol": "USDT",
+                    "decimals": 6,
+                    "balance": 40.070413,
+                    "price": 1.0027057369860566,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdAC17F958D2ee523a2206206994597C13D831ec7/logo.png"
+                  }
+                ],
+                "balance": 1
+              },
+              {
+                "address": "0x3660F04B79751e31128f6378eAC70807e38f554E",
+                "name": "BBS / USDC",
+                "symbol": "BBS / USDC",
+                "decimals": 18,
+                "type": "protocol",
+                "tokenId": "32667107224410092492483962313449748300520",
+                "balanceRaw": "1000000000000000000n",
+                "tokens": [
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "4796297636542810062982n",
+                    "address": "0xFe459828c90c0BA4bC8b42F5C5D44F316700B430",
+                    "name": "BBS",
+                    "symbol": "BBS",
+                    "decimals": 18,
+                    "balance": 4796.29763654281,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xFe459828c90c0BA4bC8b42F5C5D44F316700B430/logo.png"
+                  },
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "0n",
+                    "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                    "name": "USD Coin",
+                    "symbol": "USDC",
+                    "decimals": 6,
+                    "balance": 0,
+                    "price": 1.003138130924194,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
+                  }
+                ],
+                "balance": 1
+              }
+            ],
+            "rawWithdrawals": [],
+            "rawDeposits": []
+          }
+        },
+        {
+          "address": "0x3660F04B79751e31128f6378eAC70807e38f554E",
+          "name": "USDC / DAI",
+          "symbol": "USDC / DAI",
+          "decimals": 18,
+          "tokenId": "1361129467683753853853498429727072845828",
+          "type": "protocol",
+          "profit": -0.2821952106543719,
+          "performance": -0.0056228778666402,
+          "calculationData": {
+            "withdrawals": 0,
+            "deposits": 0,
+            "startPositionValue": 50.186971395661864,
+            "endPositionValue": 49.90477618500749
+          },
+          "rawValues": {
+            "rawEndPositionValues": [
+              {
+                "address": "0x3660F04B79751e31128f6378eAC70807e38f554E",
+                "name": "ETH / stETH",
+                "symbol": "ETH / stETH",
+                "decimals": 18,
+                "type": "protocol",
+                "tokenId": "680564733841876926926749214863536422914",
+                "balanceRaw": "1000000000000000000n",
+                "tokens": [
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "0n",
+                    "address": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+                    "name": "Ethereum",
+                    "symbol": "ETH",
+                    "decimals": 18,
+                    "balance": 0,
+                    "price": 2421.72692,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/info/logo.png"
+                  },
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "0n",
+                    "address": "0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84",
+                    "name": "Liquid staked Ether 2.0",
+                    "symbol": "stETH",
+                    "decimals": 18,
+                    "tokens": [
+                      {
+                        "address": "0x0000000000000000000000000000000000000000",
+                        "name": "Ethereum",
+                        "symbol": "ETH",
+                        "decimals": 18,
+                        "type": "underlying",
+                        "balanceRaw": "0n",
+                        "balance": 0,
+                        "price": 2421.72692,
+                        "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/info/logo.png"
+                      }
+                    ],
+                    "balance": 0,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84/logo.png"
+                  }
+                ],
+                "balance": 1
+              },
+              {
+                "address": "0x3660F04B79751e31128f6378eAC70807e38f554E",
+                "name": "USDC / USDT",
+                "symbol": "USDC / USDT",
+                "decimals": 18,
+                "type": "protocol",
+                "tokenId": "1020847100762815390390123822295304634371",
+                "balanceRaw": "1000000000000000000n",
+                "tokens": [
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "0n",
+                    "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                    "name": "USD Coin",
+                    "symbol": "USDC",
+                    "decimals": 6,
+                    "balance": 0,
+                    "price": 0.9974964416136795,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
+                  },
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "100256523n",
+                    "address": "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+                    "name": "Tether USD",
+                    "symbol": "USDT",
+                    "decimals": 6,
+                    "balance": 100.256523,
+                    "price": 0.9974515833602204,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdAC17F958D2ee523a2206206994597C13D831ec7/logo.png"
+                  }
+                ],
+                "balance": 1
+              },
+              {
+                "address": "0x3660F04B79751e31128f6378eAC70807e38f554E",
+                "name": "USDC / DAI",
+                "symbol": "USDC / DAI",
+                "decimals": 18,
+                "type": "protocol",
+                "tokenId": "1361129467683753853853498429727072845828",
+                "balanceRaw": "1000000000000000000n",
+                "tokens": [
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "50000000n",
+                    "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                    "name": "USD Coin",
+                    "symbol": "USDC",
+                    "decimals": 6,
+                    "balance": 50,
+                    "price": 0.9974964416136795,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
+                  },
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "30000000000064988n",
+                    "address": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+                    "name": "Dai Stablecoin",
+                    "symbol": "DAI",
+                    "decimals": 18,
+                    "balance": 0.03000000000006499,
+                    "price": 0.9984701441151138,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png"
+                  }
+                ],
+                "balance": 1
+              },
+              {
+                "address": "0x3660F04B79751e31128f6378eAC70807e38f554E",
+                "name": "DAI / USDT",
+                "symbol": "DAI / USDT",
+                "decimals": 18,
+                "type": "protocol",
+                "tokenId": "2041694201525630780780247644590609268742",
+                "balanceRaw": "1000000000000000000n",
+                "tokens": [
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "5820057695805493n",
+                    "address": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+                    "name": "Dai Stablecoin",
+                    "symbol": "DAI",
+                    "decimals": 18,
+                    "balance": 0.005820057695805493,
+                    "price": 0.9984701441151138,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png"
+                  },
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "40070413n",
+                    "address": "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+                    "name": "Tether USD",
+                    "symbol": "USDT",
+                    "decimals": 6,
+                    "balance": 40.070413,
+                    "price": 0.9974515833602204,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdAC17F958D2ee523a2206206994597C13D831ec7/logo.png"
+                  }
+                ],
+                "balance": 1
+              },
+              {
+                "address": "0x3660F04B79751e31128f6378eAC70807e38f554E",
+                "name": "BBS / USDC",
+                "symbol": "BBS / USDC",
+                "decimals": 18,
+                "type": "protocol",
+                "tokenId": "32667107224410092492483962313449748300520",
+                "balanceRaw": "1000000000000000000n",
+                "tokens": [
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "4796297636542810062982n",
+                    "address": "0xFe459828c90c0BA4bC8b42F5C5D44F316700B430",
+                    "name": "BBS",
+                    "symbol": "BBS",
+                    "decimals": 18,
+                    "balance": 4796.29763654281,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xFe459828c90c0BA4bC8b42F5C5D44F316700B430/logo.png"
+                  },
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "0n",
+                    "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                    "name": "USD Coin",
+                    "symbol": "USDC",
+                    "decimals": 6,
+                    "balance": 0,
+                    "price": 0.9974964416136795,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
+                  }
+                ],
+                "balance": 1
+              }
+            ],
+            "rawStartPositionValues": [
+              {
+                "address": "0x3660F04B79751e31128f6378eAC70807e38f554E",
+                "name": "ETH / stETH",
+                "symbol": "ETH / stETH",
+                "decimals": 18,
+                "type": "protocol",
+                "tokenId": "680564733841876926926749214863536422914",
+                "balanceRaw": "1000000000000000000n",
+                "tokens": [
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "0n",
+                    "address": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+                    "name": "Ethereum",
+                    "symbol": "ETH",
+                    "decimals": 18,
+                    "balance": 0,
+                    "price": 2289.69086146,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/info/logo.png"
+                  },
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "0n",
+                    "address": "0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84",
+                    "name": "Liquid staked Ether 2.0",
+                    "symbol": "stETH",
+                    "decimals": 18,
+                    "tokens": [
+                      {
+                        "address": "0x0000000000000000000000000000000000000000",
+                        "name": "Ethereum",
+                        "symbol": "ETH",
+                        "decimals": 18,
+                        "type": "underlying",
+                        "balanceRaw": "0n",
+                        "balance": 0,
+                        "price": 2289.69086146,
+                        "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/info/logo.png"
+                      }
+                    ],
+                    "balance": 0,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84/logo.png"
+                  }
+                ],
+                "balance": 1
+              },
+              {
+                "address": "0x3660F04B79751e31128f6378eAC70807e38f554E",
+                "name": "USDC / USDT",
+                "symbol": "USDC / USDT",
+                "decimals": 18,
+                "type": "protocol",
+                "tokenId": "1020847100762815390390123822295304634371",
+                "balanceRaw": "1000000000000000000n",
+                "tokens": [
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "0n",
+                    "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                    "name": "USD Coin",
+                    "symbol": "USDC",
+                    "decimals": 6,
+                    "balance": 0,
+                    "price": 1.003138130924194,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
+                  },
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "100256523n",
+                    "address": "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+                    "name": "Tether USD",
+                    "symbol": "USDT",
+                    "decimals": 6,
+                    "balance": 100.256523,
+                    "price": 1.0027057369860566,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdAC17F958D2ee523a2206206994597C13D831ec7/logo.png"
+                  }
+                ],
+                "balance": 1
+              },
+              {
+                "address": "0x3660F04B79751e31128f6378eAC70807e38f554E",
+                "name": "USDC / DAI",
+                "symbol": "USDC / DAI",
+                "decimals": 18,
+                "type": "protocol",
+                "tokenId": "1361129467683753853853498429727072845828",
+                "balanceRaw": "1000000000000000000n",
+                "tokens": [
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "50000000n",
+                    "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                    "name": "USD Coin",
+                    "symbol": "USDC",
+                    "decimals": 6,
+                    "balance": 50,
+                    "price": 1.003138130924194,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
+                  },
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "30000000000064988n",
+                    "address": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+                    "name": "Dai Stablecoin",
+                    "symbol": "DAI",
+                    "decimals": 18,
+                    "balance": 0.03000000000006499,
+                    "price": 1.0021616484031988,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png"
+                  }
+                ],
+                "balance": 1
+              },
+              {
+                "address": "0x3660F04B79751e31128f6378eAC70807e38f554E",
+                "name": "DAI / USDT",
+                "symbol": "DAI / USDT",
+                "decimals": 18,
+                "type": "protocol",
+                "tokenId": "2041694201525630780780247644590609268742",
+                "balanceRaw": "1000000000000000000n",
+                "tokens": [
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "5820057695805493n",
+                    "address": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+                    "name": "Dai Stablecoin",
+                    "symbol": "DAI",
+                    "decimals": 18,
+                    "balance": 0.005820057695805493,
+                    "price": 1.0021616484031988,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png"
+                  },
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "40070413n",
+                    "address": "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+                    "name": "Tether USD",
+                    "symbol": "USDT",
+                    "decimals": 6,
+                    "balance": 40.070413,
+                    "price": 1.0027057369860566,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdAC17F958D2ee523a2206206994597C13D831ec7/logo.png"
+                  }
+                ],
+                "balance": 1
+              },
+              {
+                "address": "0x3660F04B79751e31128f6378eAC70807e38f554E",
+                "name": "BBS / USDC",
+                "symbol": "BBS / USDC",
+                "decimals": 18,
+                "type": "protocol",
+                "tokenId": "32667107224410092492483962313449748300520",
+                "balanceRaw": "1000000000000000000n",
+                "tokens": [
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "4796297636542810062982n",
+                    "address": "0xFe459828c90c0BA4bC8b42F5C5D44F316700B430",
+                    "name": "BBS",
+                    "symbol": "BBS",
+                    "decimals": 18,
+                    "balance": 4796.29763654281,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xFe459828c90c0BA4bC8b42F5C5D44F316700B430/logo.png"
+                  },
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "0n",
+                    "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                    "name": "USD Coin",
+                    "symbol": "USDC",
+                    "decimals": 6,
+                    "balance": 0,
+                    "price": 1.003138130924194,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
+                  }
+                ],
+                "balance": 1
+              }
+            ],
+            "rawWithdrawals": [],
+            "rawDeposits": []
+          }
+        },
+        {
+          "address": "0x3660F04B79751e31128f6378eAC70807e38f554E",
+          "name": "DAI / USDT",
+          "symbol": "DAI / USDT",
+          "decimals": 18,
+          "tokenId": "2041694201525630780780247644590609268742",
+          "type": "protocol",
+          "profit": -0.2105575905206507,
+          "performance": -0.005239749720007075,
+          "calculationData": {
+            "withdrawals": 0,
+            "deposits": 0,
+            "startPositionValue": 40.1846656371149,
+            "endPositionValue": 39.974108046594246
+          },
+          "rawValues": {
+            "rawEndPositionValues": [
+              {
+                "address": "0x3660F04B79751e31128f6378eAC70807e38f554E",
+                "name": "ETH / stETH",
+                "symbol": "ETH / stETH",
+                "decimals": 18,
+                "type": "protocol",
+                "tokenId": "680564733841876926926749214863536422914",
+                "balanceRaw": "1000000000000000000n",
+                "tokens": [
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "0n",
+                    "address": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+                    "name": "Ethereum",
+                    "symbol": "ETH",
+                    "decimals": 18,
+                    "balance": 0,
+                    "price": 2421.72692,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/info/logo.png"
+                  },
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "0n",
+                    "address": "0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84",
+                    "name": "Liquid staked Ether 2.0",
+                    "symbol": "stETH",
+                    "decimals": 18,
+                    "tokens": [
+                      {
+                        "address": "0x0000000000000000000000000000000000000000",
+                        "name": "Ethereum",
+                        "symbol": "ETH",
+                        "decimals": 18,
+                        "type": "underlying",
+                        "balanceRaw": "0n",
+                        "balance": 0,
+                        "price": 2421.72692,
+                        "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/info/logo.png"
+                      }
+                    ],
+                    "balance": 0,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84/logo.png"
+                  }
+                ],
+                "balance": 1
+              },
+              {
+                "address": "0x3660F04B79751e31128f6378eAC70807e38f554E",
+                "name": "USDC / USDT",
+                "symbol": "USDC / USDT",
+                "decimals": 18,
+                "type": "protocol",
+                "tokenId": "1020847100762815390390123822295304634371",
+                "balanceRaw": "1000000000000000000n",
+                "tokens": [
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "0n",
+                    "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                    "name": "USD Coin",
+                    "symbol": "USDC",
+                    "decimals": 6,
+                    "balance": 0,
+                    "price": 0.9974964416136795,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
+                  },
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "100256523n",
+                    "address": "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+                    "name": "Tether USD",
+                    "symbol": "USDT",
+                    "decimals": 6,
+                    "balance": 100.256523,
+                    "price": 0.9974515833602204,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdAC17F958D2ee523a2206206994597C13D831ec7/logo.png"
+                  }
+                ],
+                "balance": 1
+              },
+              {
+                "address": "0x3660F04B79751e31128f6378eAC70807e38f554E",
+                "name": "USDC / DAI",
+                "symbol": "USDC / DAI",
+                "decimals": 18,
+                "type": "protocol",
+                "tokenId": "1361129467683753853853498429727072845828",
+                "balanceRaw": "1000000000000000000n",
+                "tokens": [
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "50000000n",
+                    "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                    "name": "USD Coin",
+                    "symbol": "USDC",
+                    "decimals": 6,
+                    "balance": 50,
+                    "price": 0.9974964416136795,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
+                  },
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "30000000000064988n",
+                    "address": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+                    "name": "Dai Stablecoin",
+                    "symbol": "DAI",
+                    "decimals": 18,
+                    "balance": 0.03000000000006499,
+                    "price": 0.9984701441151138,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png"
+                  }
+                ],
+                "balance": 1
+              },
+              {
+                "address": "0x3660F04B79751e31128f6378eAC70807e38f554E",
+                "name": "DAI / USDT",
+                "symbol": "DAI / USDT",
+                "decimals": 18,
+                "type": "protocol",
+                "tokenId": "2041694201525630780780247644590609268742",
+                "balanceRaw": "1000000000000000000n",
+                "tokens": [
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "5820057695805493n",
+                    "address": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+                    "name": "Dai Stablecoin",
+                    "symbol": "DAI",
+                    "decimals": 18,
+                    "balance": 0.005820057695805493,
+                    "price": 0.9984701441151138,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png"
+                  },
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "40070413n",
+                    "address": "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+                    "name": "Tether USD",
+                    "symbol": "USDT",
+                    "decimals": 6,
+                    "balance": 40.070413,
+                    "price": 0.9974515833602204,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdAC17F958D2ee523a2206206994597C13D831ec7/logo.png"
+                  }
+                ],
+                "balance": 1
+              },
+              {
+                "address": "0x3660F04B79751e31128f6378eAC70807e38f554E",
+                "name": "BBS / USDC",
+                "symbol": "BBS / USDC",
+                "decimals": 18,
+                "type": "protocol",
+                "tokenId": "32667107224410092492483962313449748300520",
+                "balanceRaw": "1000000000000000000n",
+                "tokens": [
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "4796297636542810062982n",
+                    "address": "0xFe459828c90c0BA4bC8b42F5C5D44F316700B430",
+                    "name": "BBS",
+                    "symbol": "BBS",
+                    "decimals": 18,
+                    "balance": 4796.29763654281,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xFe459828c90c0BA4bC8b42F5C5D44F316700B430/logo.png"
+                  },
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "0n",
+                    "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                    "name": "USD Coin",
+                    "symbol": "USDC",
+                    "decimals": 6,
+                    "balance": 0,
+                    "price": 0.9974964416136795,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
+                  }
+                ],
+                "balance": 1
+              }
+            ],
+            "rawStartPositionValues": [
+              {
+                "address": "0x3660F04B79751e31128f6378eAC70807e38f554E",
+                "name": "ETH / stETH",
+                "symbol": "ETH / stETH",
+                "decimals": 18,
+                "type": "protocol",
+                "tokenId": "680564733841876926926749214863536422914",
+                "balanceRaw": "1000000000000000000n",
+                "tokens": [
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "0n",
+                    "address": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+                    "name": "Ethereum",
+                    "symbol": "ETH",
+                    "decimals": 18,
+                    "balance": 0,
+                    "price": 2289.69086146,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/info/logo.png"
+                  },
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "0n",
+                    "address": "0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84",
+                    "name": "Liquid staked Ether 2.0",
+                    "symbol": "stETH",
+                    "decimals": 18,
+                    "tokens": [
+                      {
+                        "address": "0x0000000000000000000000000000000000000000",
+                        "name": "Ethereum",
+                        "symbol": "ETH",
+                        "decimals": 18,
+                        "type": "underlying",
+                        "balanceRaw": "0n",
+                        "balance": 0,
+                        "price": 2289.69086146,
+                        "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/info/logo.png"
+                      }
+                    ],
+                    "balance": 0,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84/logo.png"
+                  }
+                ],
+                "balance": 1
+              },
+              {
+                "address": "0x3660F04B79751e31128f6378eAC70807e38f554E",
+                "name": "USDC / USDT",
+                "symbol": "USDC / USDT",
+                "decimals": 18,
+                "type": "protocol",
+                "tokenId": "1020847100762815390390123822295304634371",
+                "balanceRaw": "1000000000000000000n",
+                "tokens": [
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "0n",
+                    "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                    "name": "USD Coin",
+                    "symbol": "USDC",
+                    "decimals": 6,
+                    "balance": 0,
+                    "price": 1.003138130924194,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
+                  },
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "100256523n",
+                    "address": "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+                    "name": "Tether USD",
+                    "symbol": "USDT",
+                    "decimals": 6,
+                    "balance": 100.256523,
+                    "price": 1.0027057369860566,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdAC17F958D2ee523a2206206994597C13D831ec7/logo.png"
+                  }
+                ],
+                "balance": 1
+              },
+              {
+                "address": "0x3660F04B79751e31128f6378eAC70807e38f554E",
+                "name": "USDC / DAI",
+                "symbol": "USDC / DAI",
+                "decimals": 18,
+                "type": "protocol",
+                "tokenId": "1361129467683753853853498429727072845828",
+                "balanceRaw": "1000000000000000000n",
+                "tokens": [
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "50000000n",
+                    "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                    "name": "USD Coin",
+                    "symbol": "USDC",
+                    "decimals": 6,
+                    "balance": 50,
+                    "price": 1.003138130924194,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
+                  },
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "30000000000064988n",
+                    "address": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+                    "name": "Dai Stablecoin",
+                    "symbol": "DAI",
+                    "decimals": 18,
+                    "balance": 0.03000000000006499,
+                    "price": 1.0021616484031988,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png"
+                  }
+                ],
+                "balance": 1
+              },
+              {
+                "address": "0x3660F04B79751e31128f6378eAC70807e38f554E",
+                "name": "DAI / USDT",
+                "symbol": "DAI / USDT",
+                "decimals": 18,
+                "type": "protocol",
+                "tokenId": "2041694201525630780780247644590609268742",
+                "balanceRaw": "1000000000000000000n",
+                "tokens": [
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "5820057695805493n",
+                    "address": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+                    "name": "Dai Stablecoin",
+                    "symbol": "DAI",
+                    "decimals": 18,
+                    "balance": 0.005820057695805493,
+                    "price": 1.0021616484031988,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png"
+                  },
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "40070413n",
+                    "address": "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+                    "name": "Tether USD",
+                    "symbol": "USDT",
+                    "decimals": 6,
+                    "balance": 40.070413,
+                    "price": 1.0027057369860566,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdAC17F958D2ee523a2206206994597C13D831ec7/logo.png"
+                  }
+                ],
+                "balance": 1
+              },
+              {
+                "address": "0x3660F04B79751e31128f6378eAC70807e38f554E",
+                "name": "BBS / USDC",
+                "symbol": "BBS / USDC",
+                "decimals": 18,
+                "type": "protocol",
+                "tokenId": "32667107224410092492483962313449748300520",
+                "balanceRaw": "1000000000000000000n",
+                "tokens": [
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "4796297636542810062982n",
+                    "address": "0xFe459828c90c0BA4bC8b42F5C5D44F316700B430",
+                    "name": "BBS",
+                    "symbol": "BBS",
+                    "decimals": 18,
+                    "balance": 4796.29763654281,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xFe459828c90c0BA4bC8b42F5C5D44F316700B430/logo.png"
+                  },
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "0n",
+                    "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                    "name": "USD Coin",
+                    "symbol": "USDC",
+                    "decimals": 6,
+                    "balance": 0,
+                    "price": 1.003138130924194,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
+                  }
+                ],
+                "balance": 1
+              }
+            ],
+            "rawWithdrawals": [],
+            "rawDeposits": []
+          }
+        },
+        {
+          "address": "0x3660F04B79751e31128f6378eAC70807e38f554E",
+          "name": "BBS / USDC",
+          "symbol": "BBS / USDC",
+          "decimals": 18,
+          "tokenId": "32667107224410092492483962313449748300520",
+          "type": "protocol",
+          "profit": 0,
+          "performance": 0,
+          "calculationData": {
+            "withdrawals": 0,
+            "deposits": 0,
+            "startPositionValue": 0,
+            "endPositionValue": 0
+          },
+          "rawValues": {
+            "rawEndPositionValues": [
+              {
+                "address": "0x3660F04B79751e31128f6378eAC70807e38f554E",
+                "name": "ETH / stETH",
+                "symbol": "ETH / stETH",
+                "decimals": 18,
+                "type": "protocol",
+                "tokenId": "680564733841876926926749214863536422914",
+                "balanceRaw": "1000000000000000000n",
+                "tokens": [
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "0n",
+                    "address": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+                    "name": "Ethereum",
+                    "symbol": "ETH",
+                    "decimals": 18,
+                    "balance": 0,
+                    "price": 2421.72692,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/info/logo.png"
+                  },
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "0n",
+                    "address": "0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84",
+                    "name": "Liquid staked Ether 2.0",
+                    "symbol": "stETH",
+                    "decimals": 18,
+                    "tokens": [
+                      {
+                        "address": "0x0000000000000000000000000000000000000000",
+                        "name": "Ethereum",
+                        "symbol": "ETH",
+                        "decimals": 18,
+                        "type": "underlying",
+                        "balanceRaw": "0n",
+                        "balance": 0,
+                        "price": 2421.72692,
+                        "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/info/logo.png"
+                      }
+                    ],
+                    "balance": 0,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84/logo.png"
+                  }
+                ],
+                "balance": 1
+              },
+              {
+                "address": "0x3660F04B79751e31128f6378eAC70807e38f554E",
+                "name": "USDC / USDT",
+                "symbol": "USDC / USDT",
+                "decimals": 18,
+                "type": "protocol",
+                "tokenId": "1020847100762815390390123822295304634371",
+                "balanceRaw": "1000000000000000000n",
+                "tokens": [
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "0n",
+                    "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                    "name": "USD Coin",
+                    "symbol": "USDC",
+                    "decimals": 6,
+                    "balance": 0,
+                    "price": 0.9974964416136795,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
+                  },
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "100256523n",
+                    "address": "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+                    "name": "Tether USD",
+                    "symbol": "USDT",
+                    "decimals": 6,
+                    "balance": 100.256523,
+                    "price": 0.9974515833602204,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdAC17F958D2ee523a2206206994597C13D831ec7/logo.png"
+                  }
+                ],
+                "balance": 1
+              },
+              {
+                "address": "0x3660F04B79751e31128f6378eAC70807e38f554E",
+                "name": "USDC / DAI",
+                "symbol": "USDC / DAI",
+                "decimals": 18,
+                "type": "protocol",
+                "tokenId": "1361129467683753853853498429727072845828",
+                "balanceRaw": "1000000000000000000n",
+                "tokens": [
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "50000000n",
+                    "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                    "name": "USD Coin",
+                    "symbol": "USDC",
+                    "decimals": 6,
+                    "balance": 50,
+                    "price": 0.9974964416136795,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
+                  },
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "30000000000064988n",
+                    "address": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+                    "name": "Dai Stablecoin",
+                    "symbol": "DAI",
+                    "decimals": 18,
+                    "balance": 0.03000000000006499,
+                    "price": 0.9984701441151138,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png"
+                  }
+                ],
+                "balance": 1
+              },
+              {
+                "address": "0x3660F04B79751e31128f6378eAC70807e38f554E",
+                "name": "DAI / USDT",
+                "symbol": "DAI / USDT",
+                "decimals": 18,
+                "type": "protocol",
+                "tokenId": "2041694201525630780780247644590609268742",
+                "balanceRaw": "1000000000000000000n",
+                "tokens": [
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "5820057695805493n",
+                    "address": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+                    "name": "Dai Stablecoin",
+                    "symbol": "DAI",
+                    "decimals": 18,
+                    "balance": 0.005820057695805493,
+                    "price": 0.9984701441151138,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png"
+                  },
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "40070413n",
+                    "address": "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+                    "name": "Tether USD",
+                    "symbol": "USDT",
+                    "decimals": 6,
+                    "balance": 40.070413,
+                    "price": 0.9974515833602204,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdAC17F958D2ee523a2206206994597C13D831ec7/logo.png"
+                  }
+                ],
+                "balance": 1
+              },
+              {
+                "address": "0x3660F04B79751e31128f6378eAC70807e38f554E",
+                "name": "BBS / USDC",
+                "symbol": "BBS / USDC",
+                "decimals": 18,
+                "type": "protocol",
+                "tokenId": "32667107224410092492483962313449748300520",
+                "balanceRaw": "1000000000000000000n",
+                "tokens": [
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "4796297636542810062982n",
+                    "address": "0xFe459828c90c0BA4bC8b42F5C5D44F316700B430",
+                    "name": "BBS",
+                    "symbol": "BBS",
+                    "decimals": 18,
+                    "balance": 4796.29763654281,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xFe459828c90c0BA4bC8b42F5C5D44F316700B430/logo.png"
+                  },
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "0n",
+                    "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                    "name": "USD Coin",
+                    "symbol": "USDC",
+                    "decimals": 6,
+                    "balance": 0,
+                    "price": 0.9974964416136795,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
+                  }
+                ],
+                "balance": 1
+              }
+            ],
+            "rawStartPositionValues": [
+              {
+                "address": "0x3660F04B79751e31128f6378eAC70807e38f554E",
+                "name": "ETH / stETH",
+                "symbol": "ETH / stETH",
+                "decimals": 18,
+                "type": "protocol",
+                "tokenId": "680564733841876926926749214863536422914",
+                "balanceRaw": "1000000000000000000n",
+                "tokens": [
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "0n",
+                    "address": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+                    "name": "Ethereum",
+                    "symbol": "ETH",
+                    "decimals": 18,
+                    "balance": 0,
+                    "price": 2289.69086146,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/info/logo.png"
+                  },
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "0n",
+                    "address": "0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84",
+                    "name": "Liquid staked Ether 2.0",
+                    "symbol": "stETH",
+                    "decimals": 18,
+                    "tokens": [
+                      {
+                        "address": "0x0000000000000000000000000000000000000000",
+                        "name": "Ethereum",
+                        "symbol": "ETH",
+                        "decimals": 18,
+                        "type": "underlying",
+                        "balanceRaw": "0n",
+                        "balance": 0,
+                        "price": 2289.69086146,
+                        "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/info/logo.png"
+                      }
+                    ],
+                    "balance": 0,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84/logo.png"
+                  }
+                ],
+                "balance": 1
+              },
+              {
+                "address": "0x3660F04B79751e31128f6378eAC70807e38f554E",
+                "name": "USDC / USDT",
+                "symbol": "USDC / USDT",
+                "decimals": 18,
+                "type": "protocol",
+                "tokenId": "1020847100762815390390123822295304634371",
+                "balanceRaw": "1000000000000000000n",
+                "tokens": [
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "0n",
+                    "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                    "name": "USD Coin",
+                    "symbol": "USDC",
+                    "decimals": 6,
+                    "balance": 0,
+                    "price": 1.003138130924194,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
+                  },
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "100256523n",
+                    "address": "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+                    "name": "Tether USD",
+                    "symbol": "USDT",
+                    "decimals": 6,
+                    "balance": 100.256523,
+                    "price": 1.0027057369860566,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdAC17F958D2ee523a2206206994597C13D831ec7/logo.png"
+                  }
+                ],
+                "balance": 1
+              },
+              {
+                "address": "0x3660F04B79751e31128f6378eAC70807e38f554E",
+                "name": "USDC / DAI",
+                "symbol": "USDC / DAI",
+                "decimals": 18,
+                "type": "protocol",
+                "tokenId": "1361129467683753853853498429727072845828",
+                "balanceRaw": "1000000000000000000n",
+                "tokens": [
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "50000000n",
+                    "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                    "name": "USD Coin",
+                    "symbol": "USDC",
+                    "decimals": 6,
+                    "balance": 50,
+                    "price": 1.003138130924194,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
+                  },
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "30000000000064988n",
+                    "address": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+                    "name": "Dai Stablecoin",
+                    "symbol": "DAI",
+                    "decimals": 18,
+                    "balance": 0.03000000000006499,
+                    "price": 1.0021616484031988,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png"
+                  }
+                ],
+                "balance": 1
+              },
+              {
+                "address": "0x3660F04B79751e31128f6378eAC70807e38f554E",
+                "name": "DAI / USDT",
+                "symbol": "DAI / USDT",
+                "decimals": 18,
+                "type": "protocol",
+                "tokenId": "2041694201525630780780247644590609268742",
+                "balanceRaw": "1000000000000000000n",
+                "tokens": [
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "5820057695805493n",
+                    "address": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+                    "name": "Dai Stablecoin",
+                    "symbol": "DAI",
+                    "decimals": 18,
+                    "balance": 0.005820057695805493,
+                    "price": 1.0021616484031988,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png"
+                  },
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "40070413n",
+                    "address": "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+                    "name": "Tether USD",
+                    "symbol": "USDT",
+                    "decimals": 6,
+                    "balance": 40.070413,
+                    "price": 1.0027057369860566,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdAC17F958D2ee523a2206206994597C13D831ec7/logo.png"
+                  }
+                ],
+                "balance": 1
+              },
+              {
+                "address": "0x3660F04B79751e31128f6378eAC70807e38f554E",
+                "name": "BBS / USDC",
+                "symbol": "BBS / USDC",
+                "decimals": 18,
+                "type": "protocol",
+                "tokenId": "32667107224410092492483962313449748300520",
+                "balanceRaw": "1000000000000000000n",
+                "tokens": [
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "4796297636542810062982n",
+                    "address": "0xFe459828c90c0BA4bC8b42F5C5D44F316700B430",
+                    "name": "BBS",
+                    "symbol": "BBS",
+                    "decimals": 18,
+                    "balance": 4796.29763654281,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xFe459828c90c0BA4bC8b42F5C5D44F316700B430/logo.png"
+                  },
+                  {
+                    "type": "underlying",
+                    "balanceRaw": "0n",
+                    "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                    "name": "USD Coin",
+                    "symbol": "USDC",
+                    "decimals": 6,
+                    "balance": 0,
+                    "price": 1.003138130924194,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
+                  }
+                ],
+                "balance": 1
+              }
+            ],
+            "rawWithdrawals": [],
+            "rawDeposits": []
+          }
+        }
+      ],
+      "fromBlock": 19134931,
+      "toBlock": 19184953
+    }
+  ]
+}

--- a/src/adapters/carbon-defi/tests/testCases.ts
+++ b/src/adapters/carbon-defi/tests/testCases.ts
@@ -89,4 +89,15 @@ export const testCases: TestCase[] = [
     },
     blockNumber: 19184953,
   },
+  {
+    chainId: Chain.Ethereum,
+    method: 'profits',
+    key: 'profits3',
+    input: {
+      userAddress: '0x5f7a009664B771E889751f4FD721aDc439033ECD',
+      timePeriod: TimePeriod.sevenDays,
+      includeRawValues: true,
+    },
+    blockNumber: 19184953,
+  },
 ]

--- a/src/adapters/chimp-exchange/products/pool/chimpExchangePoolAdapter.ts
+++ b/src/adapters/chimp-exchange/products/pool/chimpExchangePoolAdapter.ts
@@ -384,7 +384,15 @@ export class ChimpExchangePoolAdapter
     const poolMetadata = (await this.buildMetadata())[protocolTokenAddress]
 
     if (!poolMetadata) {
-      logger.error({ protocolTokenAddress }, 'Protocol token pool not found')
+      logger.error(
+        {
+          protocolTokenAddress,
+          protocol: this.protocolId,
+          chainId: this.chainId,
+          product: this.productId,
+        },
+        'Protocol token pool not found',
+      )
       throw new Error('Protocol token pool not found')
     }
 

--- a/src/adapters/chimp-exchange/tests/snapshots/linea.profits.json
+++ b/src/adapters/chimp-exchange/tests/snapshots/linea.profits.json
@@ -10,13 +10,45 @@
       "positionType": "supply",
       "chainId": 59144,
       "productId": "pool",
-      "success": false,
-      "error": {
-        "message": "Unable to calculate profits, missing USD price for token position 0x176211869cA2b568f2A7D4EE941E073a821EE1ff",
-        "details": {
-          "name": "Error"
+      "success": true,
+      "tokens": [
+        {
+          "address": "0x90D8053f7E29FaAF5189BdcE796a516E29F1F5d3",
+          "name": "Chimp USDC-DAI-USDT Stable Pool",
+          "symbol": "USDC-DAI-USDT",
+          "decimals": 18,
+          "type": "protocol",
+          "profit": 0,
+          "performance": 0,
+          "calculationData": {
+            "withdrawals": 0,
+            "deposits": 0,
+            "startPositionValue": 0,
+            "endPositionValue": 0,
+            "hasTokensWithoutUSDPrices": true,
+            "tokensWithoutUSDPrices": [
+              {
+                "address": "0xA219439258ca9da29E9Cc4cE5596924745e12B93",
+                "name": "Tether USD",
+                "symbol": "USDT",
+                "decimals": 6,
+                "balanceRaw": "8656585n",
+                "type": "underlying"
+              },
+              {
+                "address": "0xA219439258ca9da29E9Cc4cE5596924745e12B93",
+                "name": "Tether USD",
+                "symbol": "USDT",
+                "decimals": 6,
+                "balanceRaw": "24668512n",
+                "type": "underlying"
+              }
+            ]
+          }
         }
-      }
+      ],
+      "fromBlock": 1448288,
+      "toBlock": 1498597
     }
   ]
 }

--- a/src/adapters/compound/products/pool/compoundPoolAdapter.ts
+++ b/src/adapters/compound/products/pool/compoundPoolAdapter.ts
@@ -218,7 +218,15 @@ export class CompoundPoolAdapter
     const poolMetadata = (await this.buildMetadata())[protocolTokenAddress]
 
     if (!poolMetadata) {
-      logger.error({ protocolTokenAddress }, 'Protocol token pool not found')
+      logger.error(
+        {
+          protocolTokenAddress,
+          protocol: this.protocolId,
+          chainId: this.chainId,
+          product: this.productId,
+        },
+        'Protocol token pool not found',
+      )
       throw new Error('Protocol token pool not found')
     }
 

--- a/src/adapters/convex/products/cvxcrv-wrapper/convexCvxcrvWrapperAdapter.ts
+++ b/src/adapters/convex/products/cvxcrv-wrapper/convexCvxcrvWrapperAdapter.ts
@@ -271,7 +271,15 @@ export class ConvexCvxcrvWrapperAdapter
     const poolMetadata = (await this.buildMetadata())[protocolTokenAddress]
 
     if (!poolMetadata) {
-      logger.error({ protocolTokenAddress }, 'Protocol token pool not found')
+      logger.error(
+        {
+          protocolTokenAddress,
+          protocol: this.protocolId,
+          chainId: this.chainId,
+          product: this.productId,
+        },
+        'Protocol token pool not found',
+      )
       throw new Error('Protocol token pool not found')
     }
 

--- a/src/adapters/convex/products/cvxcrv-wrapper/metadata/ethereum.protocol-token.json
+++ b/src/adapters/convex/products/cvxcrv-wrapper/metadata/ethereum.protocol-token.json
@@ -15,14 +15,14 @@
       },
       {
         "address": "0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B",
-        "name": "Convex Token",
+        "name": "Convex Finance",
         "symbol": "CVX",
         "decimals": 18
       },
       {
         "address": "0x6c3F90f043a72FA612cbac8115EE7e52BDe6E490",
-        "name": "Curve.fi DAI/USDC/USDT",
-        "symbol": "3Crv",
+        "name": "LP 3pool Curve",
+        "symbol": "3CRV",
         "decimals": 18
       }
     ]

--- a/src/adapters/convex/products/extra-reward/convexExtraRewardAdapter.ts
+++ b/src/adapters/convex/products/extra-reward/convexExtraRewardAdapter.ts
@@ -328,7 +328,15 @@ export class ConvexExtraRewardAdapter
     const poolMetadata = (await this.buildMetadata())[protocolTokenAddress]
 
     if (!poolMetadata) {
-      logger.error({ protocolTokenAddress }, 'Protocol token pool not found')
+      logger.warn(
+        {
+          protocolTokenAddress,
+          protocol: this.protocolId,
+          chainId: this.chainId,
+          product: this.productId,
+        },
+        'Protocol token pool not found',
+      )
       throw new Error('Protocol token pool not found')
     }
 

--- a/src/adapters/convex/products/extra-reward/convexExtraRewardAdapter.ts
+++ b/src/adapters/convex/products/extra-reward/convexExtraRewardAdapter.ts
@@ -328,7 +328,7 @@ export class ConvexExtraRewardAdapter
     const poolMetadata = (await this.buildMetadata())[protocolTokenAddress]
 
     if (!poolMetadata) {
-      logger.warn(
+      logger.error(
         {
           protocolTokenAddress,
           protocol: this.protocolId,

--- a/src/adapters/convex/products/extra-reward/metadata/ethereum.protocol-token.json
+++ b/src/adapters/convex/products/extra-reward/metadata/ethereum.protocol-token.json
@@ -16,6 +16,132 @@
       }
     ]
   },
+  "0xDBFa6187C79f4fE4Cda20609E75760C5AaE88e52": {
+    "protocolToken": {
+      "address": "0xDBFa6187C79f4fE4Cda20609E75760C5AaE88e52",
+      "name": "Curve.fi MUSD/3Crv Convex Deposit",
+      "symbol": "cvxmusd3CRV",
+      "decimals": 18
+    },
+    "underlyingTokens": [
+      {
+        "address": "0xa3BeD4E1c75D00fa6f4E5E6922DB7261B5E9AcD2",
+        "name": "Meta",
+        "symbol": "MTA",
+        "decimals": 18,
+        "claimableTrackerAddress": "0x93A5C724c4992FCBDA6b96F06fa15EB8B5c485b7"
+      }
+    ]
+  },
+  "0xedfCCF611D7c40F43e77a1340cE2C29EEEC27205": {
+    "protocolToken": {
+      "address": "0xedfCCF611D7c40F43e77a1340cE2C29EEEC27205",
+      "name": "Curve.fi RSV/3Crv Convex Deposit",
+      "symbol": "cvxrsv3CRV",
+      "decimals": 18
+    },
+    "underlyingTokens": [
+      {
+        "address": "0x8762db106B2c2A0bccB3A80d1Ed41273552616E8",
+        "name": "Reserve Rights",
+        "symbol": "RSR",
+        "decimals": 18,
+        "claimableTrackerAddress": "0x94C259DC4C6dF248B0b5D23C055CB7574A587d67"
+      }
+    ]
+  },
+  "0x081A6672f07B615B402e7558a867C97FA080Ce35": {
+    "protocolToken": {
+      "address": "0x081A6672f07B615B402e7558a867C97FA080Ce35",
+      "name": "Curve.fi tBTC/sbtcCrv Convex Deposit",
+      "symbol": "cvxtbtc/sbtcCrv",
+      "decimals": 18
+    },
+    "underlyingTokens": [
+      {
+        "address": "0x85Eee30c52B0b379b046Fb0F85F4f3Dc3009aFEC",
+        "name": "KEEP",
+        "symbol": "KEEP",
+        "decimals": 18,
+        "claimableTrackerAddress": "0x2Aa030dCB729CF94bc096Bd00d377aA719A09371"
+      }
+    ]
+  },
+  "0x1992b82A8cCFC8f89785129D6403b13925d6226E": {
+    "protocolToken": {
+      "address": "0x1992b82A8cCFC8f89785129D6403b13925d6226E",
+      "name": "Curve.fi DUSD/3Crv Convex Deposit",
+      "symbol": "cvxdusd3CRV",
+      "decimals": 18
+    },
+    "underlyingTokens": [
+      {
+        "address": "0x20c36f062a31865bED8a5B1e512D9a1A20AA333A",
+        "name": "DefiDollar DAO",
+        "symbol": "DFD",
+        "decimals": 18,
+        "claimableTrackerAddress": "0x666F8eEE6FD6839853993977CC86a7A51425673C"
+      }
+    ]
+  },
+  "0x2d3C90AEB11D1393CA839Afc9587515B1325D77A": {
+    "protocolToken": {
+      "address": "0x2d3C90AEB11D1393CA839Afc9587515B1325D77A",
+      "name": "Curve.fi pBTC/sbtcCRV Convex Deposit",
+      "symbol": "cvxpBTC/sbtcCRV",
+      "decimals": 18
+    },
+    "underlyingTokens": [
+      {
+        "address": "0x89Ab32156e46F46D02ade3FEcbe5Fc4243B9AAeD",
+        "name": "pNetwork",
+        "symbol": "PNT",
+        "decimals": 18,
+        "claimableTrackerAddress": "0xAF138B29205c2246B069Ed8f0b213b205FBc14E0"
+      }
+    ]
+  },
+  "0xeeeCE77e0bc5e59c77fc408789A9A172A504bD2f": {
+    "protocolToken": {
+      "address": "0xeeeCE77e0bc5e59c77fc408789A9A172A504bD2f",
+      "name": "Curve.fi oBTC/sbtcCRV Convex Deposit",
+      "symbol": "cvxoBTC/sbtcCRV",
+      "decimals": 18
+    },
+    "underlyingTokens": [
+      {
+        "address": "0x3c9d6c1C73b31c837832c72E04D3152f051fc1A9",
+        "name": "BoringDAO",
+        "symbol": "BOR",
+        "decimals": 18,
+        "claimableTrackerAddress": "0xAE97D3766924526084dA88ba9B2bd7aF989Bf6fC"
+      },
+      {
+        "address": "0xBC19712FEB3a26080eBf6f2F7849b417FdD792CA",
+        "name": "BoringDAO",
+        "symbol": "BORING",
+        "decimals": 18,
+        "claimableTrackerAddress": "0x22a07a6bdA1CECbe2a671203e2114d8A170E5529"
+      }
+    ]
+  },
+  "0xE82c1eB4BC6F92f85BF7EB6421ab3b882C3F5a7B": {
+    "protocolToken": {
+      "address": "0xE82c1eB4BC6F92f85BF7EB6421ab3b882C3F5a7B",
+      "name": "Curve.fi aDAI/aUSDC/aUSDT Convex Deposit",
+      "symbol": "cvxa3CRV",
+      "decimals": 18
+    },
+    "underlyingTokens": [
+      {
+        "address": "0x4da27a545c0c5B758a6BA100e3a049001de870f5",
+        "name": "Staked Aave",
+        "symbol": "STKAAVE",
+        "decimals": 18,
+        "claimableTrackerAddress": "0x00469d388b06127221D6310843A43D079eb2bB18"
+      }
+    ]
+  },
   "0x0A760466E1B4621579a82a39CB56Dda2F4E70f03": {
     "protocolToken": {
       "address": "0x0A760466E1B4621579a82a39CB56Dda2F4E70f03",
@@ -37,6 +163,47 @@
         "symbol": "wstETH",
         "decimals": 18,
         "claimableTrackerAddress": "0xd5D81C39Ff47171DBF80c670CCF84b1447e1f29a"
+      }
+    ]
+  },
+  "0xF86AE6790654b70727dbE58BF1a863B270317fD0": {
+    "protocolToken": {
+      "address": "0xF86AE6790654b70727dbE58BF1a863B270317fD0",
+      "name": "Curve.fi aDAI/aSUSD Convex Deposit",
+      "symbol": "cvxsaCRV",
+      "decimals": 18
+    },
+    "underlyingTokens": [
+      {
+        "address": "0x4da27a545c0c5B758a6BA100e3a049001de870f5",
+        "name": "Staked Aave",
+        "symbol": "STKAAVE",
+        "decimals": 18,
+        "claimableTrackerAddress": "0x20165075174b51a2f9Efbf7d6D8F3c72BBc63064"
+      }
+    ]
+  },
+  "0x8798b81b0261934aa850C8de8622472bfdc143F4": {
+    "protocolToken": {
+      "address": "0x8798b81b0261934aa850C8de8622472bfdc143F4",
+      "name": "Curve.fi ETH/aETH Convex Deposit",
+      "symbol": "cvxankrCRV",
+      "decimals": 18
+    },
+    "underlyingTokens": [
+      {
+        "address": "0xE0aD1806Fd3E7edF6FF52Fdb822432e847411033",
+        "name": "OnX Finance",
+        "symbol": "ONX",
+        "decimals": 18,
+        "claimableTrackerAddress": "0x177252Ac74f1D77513971aA85AF7009C43EcdEe2"
+      },
+      {
+        "address": "0x8290333ceF9e6D528dD5618Fb97a76f268f3EDD4",
+        "name": "Ankr Network",
+        "symbol": "ANKR",
+        "decimals": 18,
+        "claimableTrackerAddress": "0xc095Cec98a9f8Ad6D2baA282A8e6bE246f98BD25"
       }
     ]
   },
@@ -71,6 +238,40 @@
         "symbol": "FXS",
         "decimals": 18,
         "claimableTrackerAddress": "0xcDEC6714eB482f28f4889A0c122868450CDBF0b0"
+      }
+    ]
+  },
+  "0x2ad92A7aE036a038ff02B96c88de868ddf3f8190": {
+    "protocolToken": {
+      "address": "0x2ad92A7aE036a038ff02B96c88de868ddf3f8190",
+      "name": "Curve.fi Factory USD Metapool: Liquity Convex Deposit",
+      "symbol": "cvxLUSD3CRV-f",
+      "decimals": 18
+    },
+    "underlyingTokens": [
+      {
+        "address": "0x6DEA81C8171D0bA574754EF6F8b412F2Ed88c54D",
+        "name": "LQTY",
+        "symbol": "LQTY",
+        "decimals": 18,
+        "claimableTrackerAddress": "0x55d59b791f06dc519B176791c4E037E8Cf2f6361"
+      }
+    ]
+  },
+  "0x61dB6c2321f784c8fAb8d5eF80f58F27C831dCc8": {
+    "protocolToken": {
+      "address": "0x61dB6c2321f784c8fAb8d5eF80f58F27C831dCc8",
+      "name": "Curve.fi ETH/rETH Convex Deposit",
+      "symbol": "cvxrCRV",
+      "decimals": 18
+    },
+    "underlyingTokens": [
+      {
+        "address": "0xef3A930e1FfFFAcd2fc13434aC81bD278B0ecC8d",
+        "name": "Stafi",
+        "symbol": "FIS",
+        "decimals": 18,
+        "claimableTrackerAddress": "0x681A790debE586A64eea055BF0983CD6629d8359"
       }
     ]
   },
@@ -118,7 +319,7 @@
     "underlyingTokens": [
       {
         "address": "0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B",
-        "name": "Convex Token",
+        "name": "Convex Finance",
         "symbol": "CVX",
         "decimals": 18,
         "claimableTrackerAddress": "0xbE4DEa8E5d1E53FAd661610E47501f858F25852D"
@@ -135,7 +336,7 @@
     "underlyingTokens": [
       {
         "address": "0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B",
-        "name": "Convex Token",
+        "name": "Convex Finance",
         "symbol": "CVX",
         "decimals": 18,
         "claimableTrackerAddress": "0xCEc9a6efFf1daF52aF12beeBf87F81bda7b95c0b"
@@ -152,7 +353,7 @@
     "underlyingTokens": [
       {
         "address": "0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B",
-        "name": "Convex Token",
+        "name": "Convex Finance",
         "symbol": "CVX",
         "decimals": 18,
         "claimableTrackerAddress": "0xb9E2e39c9C804a01f1FCB4e86F765774D511D535"
@@ -169,7 +370,7 @@
     "underlyingTokens": [
       {
         "address": "0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B",
-        "name": "Convex Token",
+        "name": "Convex Finance",
         "symbol": "CVX",
         "decimals": 18,
         "claimableTrackerAddress": "0x27801399D60594BFeDe955D54c3e85B2f00179c5"
@@ -186,10 +387,34 @@
     "underlyingTokens": [
       {
         "address": "0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B",
-        "name": "Convex Token",
+        "name": "Convex Finance",
         "symbol": "CVX",
         "decimals": 18,
         "claimableTrackerAddress": "0xAAf75a94394F6D06E01CcE62e2545CeFFBFA1E2D"
+      }
+    ]
+  },
+  "0x7D536a737C13561e0D2Decf1152a653B4e615158": {
+    "protocolToken": {
+      "address": "0x7D536a737C13561e0D2Decf1152a653B4e615158",
+      "name": "Curve.fi Factory USD Metapool: Origin Dollar Convex Deposit",
+      "symbol": "cvxOUSD3CRV-f",
+      "decimals": 18
+    },
+    "underlyingTokens": [
+      {
+        "address": "0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B",
+        "name": "Convex Finance",
+        "symbol": "CVX",
+        "decimals": 18,
+        "claimableTrackerAddress": "0x08EDE581D9B9ae55FA7deCc4E4331D191BbBF9dB"
+      },
+      {
+        "address": "0x8207c1FfC5B6804F6024322CcF34F29c3541Ae26",
+        "name": "Origin Protocol",
+        "symbol": "OGN",
+        "decimals": 18,
+        "claimableTrackerAddress": "0x8A05801c1512F6018e450b0F69e9Ca7b985fCea3"
       }
     ]
   },
@@ -203,7 +428,7 @@
     "underlyingTokens": [
       {
         "address": "0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B",
-        "name": "Convex Token",
+        "name": "Convex Finance",
         "symbol": "CVX",
         "decimals": 18,
         "claimableTrackerAddress": "0x880c2c5c4eA8cef892a90E3f714eB60144C08c30"
@@ -220,7 +445,7 @@
     "underlyingTokens": [
       {
         "address": "0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B",
-        "name": "Convex Token",
+        "name": "Convex Finance",
         "symbol": "CVX",
         "decimals": 18,
         "claimableTrackerAddress": "0x28a68d9c58086dAeB32d5c9297366cc91e50215D"
@@ -237,7 +462,7 @@
     "underlyingTokens": [
       {
         "address": "0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B",
-        "name": "Convex Token",
+        "name": "Convex Finance",
         "symbol": "CVX",
         "decimals": 18,
         "claimableTrackerAddress": "0x74835A39Fd0e72E142d5E83D514e3eF6E7642220"
@@ -261,7 +486,7 @@
     "underlyingTokens": [
       {
         "address": "0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B",
-        "name": "Convex Token",
+        "name": "Convex Finance",
         "symbol": "CVX",
         "decimals": 18,
         "claimableTrackerAddress": "0xE1eCBB4181378E2346EAC90Eb5606c01Aa08f052"
@@ -278,7 +503,7 @@
     "underlyingTokens": [
       {
         "address": "0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B",
-        "name": "Convex Token",
+        "name": "Convex Finance",
         "symbol": "CVX",
         "decimals": 18,
         "claimableTrackerAddress": "0x834B9147Fd23bF131644aBC6e557Daf99C5cDa15"
@@ -295,7 +520,7 @@
     "underlyingTokens": [
       {
         "address": "0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B",
-        "name": "Convex Token",
+        "name": "Convex Finance",
         "symbol": "CVX",
         "decimals": 18,
         "claimableTrackerAddress": "0xE2585F27bf5aaB7756f626D6444eD5Fc9154e606"
@@ -306,6 +531,23 @@
         "symbol": "FXS",
         "decimals": 18,
         "claimableTrackerAddress": "0x28120D9D49dBAeb5E34D6B809b842684C482EF27"
+      }
+    ]
+  },
+  "0x589761B61D8d1C8ecc36F3cFE35932670749015a": {
+    "protocolToken": {
+      "address": "0x589761B61D8d1C8ecc36F3cFE35932670749015a",
+      "name": "Curve.fi Factory BTC Metapool: pbtc Convex Deposit",
+      "symbol": "cvxpbtc/sbtcCRV-f",
+      "decimals": 18
+    },
+    "underlyingTokens": [
+      {
+        "address": "0x89Ab32156e46F46D02ade3FEcbe5Fc4243B9AAeD",
+        "name": "pNetwork",
+        "symbol": "PNT",
+        "decimals": 18,
+        "claimableTrackerAddress": "0x640eBdA6C4f8D70A484C170106478ffb289a47DA"
       }
     ]
   },
@@ -336,7 +578,7 @@
     "underlyingTokens": [
       {
         "address": "0xE80C0cd204D654CEbe8dd64A4857cAb6Be8345a3",
-        "name": "JPEG’d Governance Token",
+        "name": "JPEG d",
         "symbol": "JPEG",
         "decimals": 18,
         "claimableTrackerAddress": "0xB9e0eEdeaC5A2b92698f2dCA2f6dD154472A966c"
@@ -353,7 +595,7 @@
     "underlyingTokens": [
       {
         "address": "0x5f98805A4E8be255a32880FDeC7F6728C6568bA0",
-        "name": "LUSD Stablecoin",
+        "name": "Liquity USD",
         "symbol": "LUSD",
         "decimals": 18,
         "claimableTrackerAddress": "0xBA9ec69125719a02649FBF580943e2DA1A3F2E43"
@@ -387,7 +629,7 @@
     "underlyingTokens": [
       {
         "address": "0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B",
-        "name": "Convex Token",
+        "name": "Convex Finance",
         "symbol": "CVX",
         "decimals": 18,
         "claimableTrackerAddress": "0x1037750005323093dDD5Cd385d07969C239aE028"
@@ -428,224 +670,6 @@
       }
     ]
   },
-  "0xDBFa6187C79f4fE4Cda20609E75760C5AaE88e52": {
-    "protocolToken": {
-      "address": "0xDBFa6187C79f4fE4Cda20609E75760C5AaE88e52",
-      "name": "Curve.fi MUSD/3Crv Convex Deposit",
-      "symbol": "cvxmusd3CRV",
-      "decimals": 18
-    },
-    "underlyingTokens": [
-      {
-        "address": "0xa3BeD4E1c75D00fa6f4E5E6922DB7261B5E9AcD2",
-        "name": "Meta",
-        "symbol": "MTA",
-        "decimals": 18,
-        "claimableTrackerAddress": "0x93A5C724c4992FCBDA6b96F06fa15EB8B5c485b7"
-      }
-    ]
-  },
-  "0xedfCCF611D7c40F43e77a1340cE2C29EEEC27205": {
-    "protocolToken": {
-      "address": "0xedfCCF611D7c40F43e77a1340cE2C29EEEC27205",
-      "name": "Curve.fi RSV/3Crv Convex Deposit",
-      "symbol": "cvxrsv3CRV",
-      "decimals": 18
-    },
-    "underlyingTokens": [
-      {
-        "address": "0x8762db106B2c2A0bccB3A80d1Ed41273552616E8",
-        "name": "Reserve Rights",
-        "symbol": "RSR",
-        "decimals": 18,
-        "claimableTrackerAddress": "0x94C259DC4C6dF248B0b5D23C055CB7574A587d67"
-      }
-    ]
-  },
-  "0x081A6672f07B615B402e7558a867C97FA080Ce35": {
-    "protocolToken": {
-      "address": "0x081A6672f07B615B402e7558a867C97FA080Ce35",
-      "name": "Curve.fi tBTC/sbtcCrv Convex Deposit",
-      "symbol": "cvxtbtc/sbtcCrv",
-      "decimals": 18
-    },
-    "underlyingTokens": [
-      {
-        "address": "0x85Eee30c52B0b379b046Fb0F85F4f3Dc3009aFEC",
-        "name": "KEEP Token",
-        "symbol": "KEEP",
-        "decimals": 18,
-        "claimableTrackerAddress": "0x2Aa030dCB729CF94bc096Bd00d377aA719A09371"
-      }
-    ]
-  },
-  "0x1992b82A8cCFC8f89785129D6403b13925d6226E": {
-    "protocolToken": {
-      "address": "0x1992b82A8cCFC8f89785129D6403b13925d6226E",
-      "name": "Curve.fi DUSD/3Crv Convex Deposit",
-      "symbol": "cvxdusd3CRV",
-      "decimals": 18
-    },
-    "underlyingTokens": [
-      {
-        "address": "0x20c36f062a31865bED8a5B1e512D9a1A20AA333A",
-        "name": "DefiDollar DAO",
-        "symbol": "DFD",
-        "decimals": 18,
-        "claimableTrackerAddress": "0x666F8eEE6FD6839853993977CC86a7A51425673C"
-      }
-    ]
-  },
-  "0x2d3C90AEB11D1393CA839Afc9587515B1325D77A": {
-    "protocolToken": {
-      "address": "0x2d3C90AEB11D1393CA839Afc9587515B1325D77A",
-      "name": "Curve.fi pBTC/sbtcCRV Convex Deposit",
-      "symbol": "cvxpBTC/sbtcCRV",
-      "decimals": 18
-    },
-    "underlyingTokens": [
-      {
-        "address": "0x89Ab32156e46F46D02ade3FEcbe5Fc4243B9AAeD",
-        "name": "pNetwork Token",
-        "symbol": "PNT",
-        "decimals": 18,
-        "claimableTrackerAddress": "0xAF138B29205c2246B069Ed8f0b213b205FBc14E0"
-      }
-    ]
-  },
-  "0x589761B61D8d1C8ecc36F3cFE35932670749015a": {
-    "protocolToken": {
-      "address": "0x589761B61D8d1C8ecc36F3cFE35932670749015a",
-      "name": "Curve.fi Factory BTC Metapool: pbtc Convex Deposit",
-      "symbol": "cvxpbtc/sbtcCRV-f",
-      "decimals": 18
-    },
-    "underlyingTokens": [
-      {
-        "address": "0x89Ab32156e46F46D02ade3FEcbe5Fc4243B9AAeD",
-        "name": "pNetwork Token",
-        "symbol": "PNT",
-        "decimals": 18,
-        "claimableTrackerAddress": "0x640eBdA6C4f8D70A484C170106478ffb289a47DA"
-      }
-    ]
-  },
-  "0xeeeCE77e0bc5e59c77fc408789A9A172A504bD2f": {
-    "protocolToken": {
-      "address": "0xeeeCE77e0bc5e59c77fc408789A9A172A504bD2f",
-      "name": "Curve.fi oBTC/sbtcCRV Convex Deposit",
-      "symbol": "cvxoBTC/sbtcCRV",
-      "decimals": 18
-    },
-    "underlyingTokens": [
-      {
-        "address": "0x3c9d6c1C73b31c837832c72E04D3152f051fc1A9",
-        "name": "BoringDAO",
-        "symbol": "BOR",
-        "decimals": 18,
-        "claimableTrackerAddress": "0xAE97D3766924526084dA88ba9B2bd7aF989Bf6fC"
-      },
-      {
-        "address": "0xBC19712FEB3a26080eBf6f2F7849b417FdD792CA",
-        "name": "BoringDAO",
-        "symbol": "BORING",
-        "decimals": 18,
-        "claimableTrackerAddress": "0x22a07a6bdA1CECbe2a671203e2114d8A170E5529"
-      }
-    ]
-  },
-  "0xE82c1eB4BC6F92f85BF7EB6421ab3b882C3F5a7B": {
-    "protocolToken": {
-      "address": "0xE82c1eB4BC6F92f85BF7EB6421ab3b882C3F5a7B",
-      "name": "Curve.fi aDAI/aUSDC/aUSDT Convex Deposit",
-      "symbol": "cvxa3CRV",
-      "decimals": 18
-    },
-    "underlyingTokens": [
-      {
-        "address": "0x4da27a545c0c5B758a6BA100e3a049001de870f5",
-        "name": "Staked Aave",
-        "symbol": "stkAAVE",
-        "decimals": 18,
-        "claimableTrackerAddress": "0x00469d388b06127221D6310843A43D079eb2bB18"
-      }
-    ]
-  },
-  "0xF86AE6790654b70727dbE58BF1a863B270317fD0": {
-    "protocolToken": {
-      "address": "0xF86AE6790654b70727dbE58BF1a863B270317fD0",
-      "name": "Curve.fi aDAI/aSUSD Convex Deposit",
-      "symbol": "cvxsaCRV",
-      "decimals": 18
-    },
-    "underlyingTokens": [
-      {
-        "address": "0x4da27a545c0c5B758a6BA100e3a049001de870f5",
-        "name": "Staked Aave",
-        "symbol": "stkAAVE",
-        "decimals": 18,
-        "claimableTrackerAddress": "0x20165075174b51a2f9Efbf7d6D8F3c72BBc63064"
-      }
-    ]
-  },
-  "0x8798b81b0261934aa850C8de8622472bfdc143F4": {
-    "protocolToken": {
-      "address": "0x8798b81b0261934aa850C8de8622472bfdc143F4",
-      "name": "Curve.fi ETH/aETH Convex Deposit",
-      "symbol": "cvxankrCRV",
-      "decimals": 18
-    },
-    "underlyingTokens": [
-      {
-        "address": "0xE0aD1806Fd3E7edF6FF52Fdb822432e847411033",
-        "name": "OnX.finance",
-        "symbol": "ONX",
-        "decimals": 18,
-        "claimableTrackerAddress": "0x177252Ac74f1D77513971aA85AF7009C43EcdEe2"
-      },
-      {
-        "address": "0x8290333ceF9e6D528dD5618Fb97a76f268f3EDD4",
-        "name": "Ankr Network",
-        "symbol": "ANKR",
-        "decimals": 18,
-        "claimableTrackerAddress": "0xc095Cec98a9f8Ad6D2baA282A8e6bE246f98BD25"
-      }
-    ]
-  },
-  "0x2ad92A7aE036a038ff02B96c88de868ddf3f8190": {
-    "protocolToken": {
-      "address": "0x2ad92A7aE036a038ff02B96c88de868ddf3f8190",
-      "name": "Curve.fi Factory USD Metapool: Liquity Convex Deposit",
-      "symbol": "cvxLUSD3CRV-f",
-      "decimals": 18
-    },
-    "underlyingTokens": [
-      {
-        "address": "0x6DEA81C8171D0bA574754EF6F8b412F2Ed88c54D",
-        "name": "LQTY",
-        "symbol": "LQTY",
-        "decimals": 18,
-        "claimableTrackerAddress": "0x55d59b791f06dc519B176791c4E037E8Cf2f6361"
-      }
-    ]
-  },
-  "0x61dB6c2321f784c8fAb8d5eF80f58F27C831dCc8": {
-    "protocolToken": {
-      "address": "0x61dB6c2321f784c8fAb8d5eF80f58F27C831dCc8",
-      "name": "Curve.fi ETH/rETH Convex Deposit",
-      "symbol": "cvxrCRV",
-      "decimals": 18
-    },
-    "underlyingTokens": [
-      {
-        "address": "0xef3A930e1FfFFAcd2fc13434aC81bD278B0ecC8d",
-        "name": "StaFi",
-        "symbol": "FIS",
-        "decimals": 18,
-        "claimableTrackerAddress": "0x681A790debE586A64eea055BF0983CD6629d8359"
-      }
-    ]
-  },
   "0xbA8fE590498ed24D330Bb925E69913b1Ac35a81E": {
     "protocolToken": {
       "address": "0xbA8fE590498ed24D330Bb925E69913b1Ac35a81E",
@@ -656,7 +680,7 @@
     "underlyingTokens": [
       {
         "address": "0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B",
-        "name": "Convex Token",
+        "name": "Convex Finance",
         "symbol": "CVX",
         "decimals": 18,
         "claimableTrackerAddress": "0x8a3F52c2Eb02De2d8356a8286c96909352c62B10"
@@ -680,7 +704,7 @@
     "underlyingTokens": [
       {
         "address": "0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B",
-        "name": "Convex Token",
+        "name": "Convex Finance",
         "symbol": "CVX",
         "decimals": 18,
         "claimableTrackerAddress": "0x00A4f5d12E3FAA909c53CDcC90968F735633e988"
@@ -704,7 +728,7 @@
     "underlyingTokens": [
       {
         "address": "0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B",
-        "name": "Convex Token",
+        "name": "Convex Finance",
         "symbol": "CVX",
         "decimals": 18,
         "claimableTrackerAddress": "0x040A6Ae6314e190974ee4839f3c2FBf849EF54Eb"
@@ -728,7 +752,7 @@
     "underlyingTokens": [
       {
         "address": "0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B",
-        "name": "Convex Token",
+        "name": "Convex Finance",
         "symbol": "CVX",
         "decimals": 18,
         "claimableTrackerAddress": "0xbA5eF047ce02cc0096DB3Bc8ED84aAD14291f8a0"
@@ -752,7 +776,7 @@
     "underlyingTokens": [
       {
         "address": "0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B",
-        "name": "Convex Token",
+        "name": "Convex Finance",
         "symbol": "CVX",
         "decimals": 18,
         "claimableTrackerAddress": "0x1c86460640457466E2eC86916B4a91ED86CE0D1E"
@@ -776,7 +800,7 @@
     "underlyingTokens": [
       {
         "address": "0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B",
-        "name": "Convex Token",
+        "name": "Convex Finance",
         "symbol": "CVX",
         "decimals": 18,
         "claimableTrackerAddress": "0x93649cd43635bC5F7Ad8fA2fa27CB9aE765Ec58A"
@@ -930,30 +954,6 @@
         "symbol": "rKP3R",
         "decimals": 18,
         "claimableTrackerAddress": "0x5ab9Ea799904185939209c30Aa180f84AC58A63b"
-      }
-    ]
-  },
-  "0x7D536a737C13561e0D2Decf1152a653B4e615158": {
-    "protocolToken": {
-      "address": "0x7D536a737C13561e0D2Decf1152a653B4e615158",
-      "name": "Curve.fi Factory USD Metapool: Origin Dollar Convex Deposit",
-      "symbol": "cvxOUSD3CRV-f",
-      "decimals": 18
-    },
-    "underlyingTokens": [
-      {
-        "address": "0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B",
-        "name": "Convex Token",
-        "symbol": "CVX",
-        "decimals": 18,
-        "claimableTrackerAddress": "0x08EDE581D9B9ae55FA7deCc4E4331D191BbBF9dB"
-      },
-      {
-        "address": "0x8207c1FfC5B6804F6024322CcF34F29c3541Ae26",
-        "name": "OriginToken",
-        "symbol": "OGN",
-        "decimals": 18,
-        "claimableTrackerAddress": "0x8A05801c1512F6018e450b0F69e9Ca7b985fCea3"
       }
     ]
   },
@@ -1247,6 +1247,13 @@
         "symbol": "CVX",
         "decimals": 18,
         "claimableTrackerAddress": "0x61bc5905745cF91f43501A9f38E23f6a2eE983A7"
+      },
+      {
+        "address": "0x176bFbABC09aab89f4d325b35B32c19cd5A2515e",
+        "name": "Alchemix",
+        "symbol": "ALCX",
+        "decimals": 18,
+        "claimableTrackerAddress": "0xEe78Acbf255f96A1C85c96425176e14033742f2B"
       }
     ]
   },
@@ -2819,6 +2826,13 @@
         "symbol": "CVX",
         "decimals": 18,
         "claimableTrackerAddress": "0xb68918F23c3f6f5f495AeFd9493C7dC0690ABe47"
+      },
+      {
+        "address": "0x7f7Faa86b2E5FbB2742905B764556C75FFe6BD45",
+        "name": "Rocket Pool Protocol",
+        "symbol": "RPL",
+        "decimals": 18,
+        "claimableTrackerAddress": "0x5EF49858Df9A03DC251f9A0E4A810b5d6dED4b16"
       }
     ]
   },
@@ -2860,6 +2874,23 @@
         "symbol": "PYUSD",
         "decimals": 6,
         "claimableTrackerAddress": "0x22A0a706Aa423E2257e4217be2268e0374b9229f"
+      }
+    ]
+  },
+  "0x72b99E2cf3f9A2bbDA1Cc76894E4554d7aA8FE2E": {
+    "protocolToken": {
+      "address": "0x72b99E2cf3f9A2bbDA1Cc76894E4554d7aA8FE2E",
+      "name": "pxETH/frxETH Convex Deposit",
+      "symbol": "cvxpxfrxeth",
+      "decimals": 18
+    },
+    "underlyingTokens": [
+      {
+        "address": "0x0bfA0FbA017aff75C825fE58F300f39FC473b7DA",
+        "name": "Convex Token",
+        "symbol": "CVX",
+        "decimals": 18,
+        "claimableTrackerAddress": "0xD23099F47AA5B25cc5305C474D8af6Cc563D8F56"
       }
     ]
   },
@@ -2931,6 +2962,23 @@
       }
     ]
   },
+  "0x830a71574E3c8AE9da477cE1B7F12849E9f7c8c8": {
+    "protocolToken": {
+      "address": "0x830a71574E3c8AE9da477cE1B7F12849E9f7c8c8",
+      "name": "FRAXFXB20240630 Convex Deposit",
+      "symbol": "cvxFXB240630",
+      "decimals": 18
+    },
+    "underlyingTokens": [
+      {
+        "address": "0x0FdC900657B12a6036691290b1275180dA10ed9c",
+        "name": "Convex Token",
+        "symbol": "CVX",
+        "decimals": 18,
+        "claimableTrackerAddress": "0xe37Ba301A15ff478853DFe8c602Ecead7286E7b8"
+      }
+    ]
+  },
   "0x249cE0b1a682AD7b02e43271f9f0C9ac85Ec47e8": {
     "protocolToken": {
       "address": "0x249cE0b1a682AD7b02e43271f9f0C9ac85Ec47e8",
@@ -2945,6 +2993,23 @@
         "symbol": "CVX",
         "decimals": 18,
         "claimableTrackerAddress": "0xA3406d258268CfBA9D497efD71f850E665Cd1076"
+      }
+    ]
+  },
+  "0xC9F6D73fD06b8EEB0A4E87cAd407219E10F31712": {
+    "protocolToken": {
+      "address": "0xC9F6D73fD06b8EEB0A4E87cAd407219E10F31712",
+      "name": "FRAXFXB20261231 Convex Deposit",
+      "symbol": "cvxFXB261231",
+      "decimals": 18
+    },
+    "underlyingTokens": [
+      {
+        "address": "0x7B895d601162069f4314a35552987B2cb99dF0Ca",
+        "name": "Convex Token",
+        "symbol": "CVX",
+        "decimals": 18,
+        "claimableTrackerAddress": "0xDc9f3f099623b91A46c9F2e496818c253d4f64D0"
       }
     ]
   },
@@ -2979,6 +3044,74 @@
         "symbol": "CVX",
         "decimals": 18,
         "claimableTrackerAddress": "0xD9f9DA2E9236A9bd6723cD31762Ed6fc2bdec274"
+      }
+    ]
+  },
+  "0x437BdEa046406130646E67514eed0aC965692963": {
+    "protocolToken": {
+      "address": "0x437BdEa046406130646E67514eed0aC965692963",
+      "name": "USDV-3crv Convex Deposit",
+      "symbol": "cvxUSDV3crv",
+      "decimals": 18
+    },
+    "underlyingTokens": [
+      {
+        "address": "0x0c686Bc5d8e4cae878FfB93Bb23552a3205C3f1F",
+        "name": "Convex Token",
+        "symbol": "CVX",
+        "decimals": 18,
+        "claimableTrackerAddress": "0xa2BF70E50F4629c5E858519eAB80F13104F18C46"
+      }
+    ]
+  },
+  "0xBdeb10ed4FE95a2f79A9D60F9C16206BfcBA6Ef7": {
+    "protocolToken": {
+      "address": "0xBdeb10ed4FE95a2f79A9D60F9C16206BfcBA6Ef7",
+      "name": "eUSD/mkUSD Convex Deposit",
+      "symbol": "cvxeUSDmkUSD",
+      "decimals": 18
+    },
+    "underlyingTokens": [
+      {
+        "address": "0x53153073baAdDe7567E9a2247b9EcEba50f5fd88",
+        "name": "Convex Token",
+        "symbol": "CVX",
+        "decimals": 18,
+        "claimableTrackerAddress": "0x0FaD00BFc34683525f9Cc130bFE8772cDc3Aa5C5"
+      }
+    ]
+  },
+  "0x01099Fe2c82C6F5Dc7485697fBC234f034E3329A": {
+    "protocolToken": {
+      "address": "0x01099Fe2c82C6F5Dc7485697fBC234f034E3329A",
+      "name": "eUSD/crvUSD Convex Deposit",
+      "symbol": "cvxeUSDcrvUSD",
+      "decimals": 18
+    },
+    "underlyingTokens": [
+      {
+        "address": "0x89B258D2a827CE2A81CbCB973ef6c57A14b358De",
+        "name": "Convex Token",
+        "symbol": "CVX",
+        "decimals": 18,
+        "claimableTrackerAddress": "0xCAc898C43437A956Af7eFB112fc74e4Ee0204d3E"
+      }
+    ]
+  },
+  "0xbf93ffB9C681052b810E300B38F59676a78f16b3": {
+    "protocolToken": {
+      "address": "0xbf93ffB9C681052b810E300B38F59676a78f16b3",
+      "name": "BobrCRV/CRV/crvUSD Convex Deposit",
+      "symbol": "cvxBobrCRV",
+      "decimals": 18
+    },
+    "underlyingTokens": [
+      {
+        "address": "0x7081a0E666604ba5751C0648A560DF0d32B237B0",
+        "name": "Convex Token",
+        "symbol": "CVX",
+        "decimals": 18,
+        "claimableTrackerAddress": "0x4541cBb45B315Acaca7d1fC709b3E7B8C628aD9E"
       }
     ]
   }

--- a/src/adapters/convex/products/pool/convexPoolAdapter.ts
+++ b/src/adapters/convex/products/pool/convexPoolAdapter.ts
@@ -169,7 +169,15 @@ export class ConvexPoolAdapter
     const poolMetadata = (await this.buildMetadata())[protocolTokenAddress]
 
     if (!poolMetadata) {
-      logger.error({ protocolTokenAddress }, 'Protocol token pool not found')
+      logger.error(
+        {
+          protocolTokenAddress,
+          protocol: this.protocolId,
+          chainId: this.chainId,
+          product: this.productId,
+        },
+        'Protocol token pool not found',
+      )
       throw new Error('Protocol token pool not found')
     }
 

--- a/src/adapters/convex/products/pool/metadata/ethereum.protocol-token.json
+++ b/src/adapters/convex/products/pool/metadata/ethereum.protocol-token.json
@@ -8,8 +8,8 @@
     },
     "underlyingToken": {
       "address": "0x845838DF265Dcd2c412A1Dc9e959c7d08537f8a2",
-      "name": "Curve.fi cDAI/cUSDC",
-      "symbol": "cDAI+cUSDC",
+      "name": "LP-cCurve",
+      "symbol": "CCURVE",
       "decimals": 18
     }
   },
@@ -36,8 +36,8 @@
     },
     "underlyingToken": {
       "address": "0xdF5e0e81Dff6FAF3A7e52BA697820c5e32D806A8",
-      "name": "Curve.fi yDAI/yUSDC/yUSDT/yTUSD",
-      "symbol": "yDAI+yUSDC+yUSDT+yTUSD",
+      "name": "LP yCurve",
+      "symbol": "YCURVE",
       "decimals": 18
     }
   },
@@ -50,8 +50,8 @@
     },
     "underlyingToken": {
       "address": "0x3B3Ac5386837Dc563660FB6a0937DFAa5924333B",
-      "name": "Curve.fi yDAI/yUSDC/yUSDT/yBUSD",
-      "symbol": "yDAI+yUSDC+yUSDT+yBUSD",
+      "name": "LP-bCurve",
+      "symbol": "BCURVE",
       "decimals": 18
     }
   },
@@ -64,8 +64,8 @@
     },
     "underlyingToken": {
       "address": "0xC25a3A3b969415c80451098fa907EC722572917F",
-      "name": "Curve.fi DAI/USDC/USDT/sUSD",
-      "symbol": "crvPlain3andSUSD",
+      "name": "LP sCurve",
+      "symbol": "SCURVE",
       "decimals": 18
     }
   },
@@ -78,8 +78,8 @@
     },
     "underlyingToken": {
       "address": "0xD905e2eaeBe188fc92179b6350807D8bd91Db0D8",
-      "name": "Curve.fi DAI/USDC/USDT/PAX",
-      "symbol": "ypaxCrv",
+      "name": "LP-paxCurve",
+      "symbol": "PAXCURVE",
       "decimals": 18
     }
   },
@@ -92,8 +92,8 @@
     },
     "underlyingToken": {
       "address": "0x49849C98ae39Fff122806C06791Fa73784FB3675",
-      "name": "Curve.fi renBTC/wBTC",
-      "symbol": "crvRenWBTC",
+      "name": "LP renBTC Curve",
+      "symbol": "RENBTCCURVE",
       "decimals": 18
     }
   },
@@ -106,8 +106,8 @@
     },
     "underlyingToken": {
       "address": "0x075b1bb99792c9E1041bA13afEf80C91a1e70fB3",
-      "name": "Curve.fi renBTC/wBTC/sBTC",
-      "symbol": "crvRenWSBTC",
+      "name": "Curve fi renBTC wBTC sBTC",
+      "symbol": "CRVRENWSBTC",
       "decimals": 18
     }
   },
@@ -134,8 +134,8 @@
     },
     "underlyingToken": {
       "address": "0x6c3F90f043a72FA612cbac8115EE7e52BDe6E490",
-      "name": "Curve.fi DAI/USDC/USDT",
-      "symbol": "3Crv",
+      "name": "LP 3pool Curve",
+      "symbol": "3CRV",
       "decimals": 18
     }
   },
@@ -470,8 +470,8 @@
     },
     "underlyingToken": {
       "address": "0xEd279fDD11cA84bEef15AF5D39BB4d4bEE23F0cA",
-      "name": "Curve.fi Factory USD Metapool: Liquity",
-      "symbol": "LUSD3CRV-f",
+      "name": "LUSD3CRV f",
+      "symbol": "LUSD3CRV",
       "decimals": 18
     }
   },
@@ -1408,8 +1408,8 @@
     },
     "underlyingToken": {
       "address": "0x3175Df0976dFA876431C2E9eE6Bc45b65d3473CC",
-      "name": "Curve.fi FRAX/USDC",
-      "symbol": "crvFRAX",
+      "name": "Curve fi FRAX USDC",
+      "symbol": "CRVFRAX",
       "decimals": 18
     }
   },
@@ -4084,6 +4084,146 @@
       "address": "0x678053c553B963f83798b54D7F69deC086D527BA",
       "name": "crvUSD/stUSDT",
       "symbol": "crvstUSDT",
+      "decimals": 18
+    }
+  },
+  "0xa41c422B418eE4e18b13F40c246D05C3013aC4c5": {
+    "protocolToken": {
+      "address": "0xa41c422B418eE4e18b13F40c246D05C3013aC4c5",
+      "name": "eUSD/mkUSD Convex Deposit",
+      "symbol": "cvxeUSDmkUSD",
+      "decimals": 18
+    },
+    "underlyingToken": {
+      "address": "0xc37c0E88551Ed383c1aBEDc6628a5579071BF56f",
+      "name": "eUSD/mkUSD",
+      "symbol": "eUSDmkUSD",
+      "decimals": 18
+    }
+  },
+  "0x16e21804A962F098F5C02Bd8E18Cb7cD26d90c2A": {
+    "protocolToken": {
+      "address": "0x16e21804A962F098F5C02Bd8E18Cb7cD26d90c2A",
+      "name": "eUSD/crvUSD Convex Deposit",
+      "symbol": "cvxeUSDcrvUSD",
+      "decimals": 18
+    },
+    "underlyingToken": {
+      "address": "0x91285c4fC766ffF6F3acAfeEC7a0423275257faE",
+      "name": "eUSD/crvUSD",
+      "symbol": "eUSDcrvUSD",
+      "decimals": 18
+    }
+  },
+  "0x99b6FD0C3C0311b237D12806b3d067Eb7D053311": {
+    "protocolToken": {
+      "address": "0x99b6FD0C3C0311b237D12806b3d067Eb7D053311",
+      "name": "weeTH/rswETH Convex Deposit",
+      "symbol": "cvxweeTH/rswE",
+      "decimals": 18
+    },
+    "underlyingToken": {
+      "address": "0x278cfB6f06B1EFc09d34fC7127d6060C61d629Db",
+      "name": "weeTH/rswETH",
+      "symbol": "weeTH/rswE",
+      "decimals": 18
+    }
+  },
+  "0x459D0282D40d2EE20BEBd4213bff77B3F5a5824c": {
+    "protocolToken": {
+      "address": "0x459D0282D40d2EE20BEBd4213bff77B3F5a5824c",
+      "name": "rswETH/ETH Convex Deposit",
+      "symbol": "cvxrswETH/ETH",
+      "decimals": 18
+    },
+    "underlyingToken": {
+      "address": "0xeE04382c4cA6c450213923fE0f0daB19b0ff3939",
+      "name": "rswETH/ETH",
+      "symbol": "rswETH/ETH",
+      "decimals": 18
+    }
+  },
+  "0x55E77245bE7AD7680E991CD6Aec3953744e35a09": {
+    "protocolToken": {
+      "address": "0x55E77245bE7AD7680E991CD6Aec3953744e35a09",
+      "name": "BobrCRV/CRV/crvUSD Convex Deposit",
+      "symbol": "cvxBobrCRV",
+      "decimals": 18
+    },
+    "underlyingToken": {
+      "address": "0x9FeE65D5A627e73212989c8BbEdC5Fa5Cae3821F",
+      "name": "BobrCRV/CRV/crvUSD",
+      "symbol": "BobrCRV",
+      "decimals": 18
+    }
+  },
+  "0xE2f351EE66e83A41bad79E45bEDFE451ffBf7199": {
+    "protocolToken": {
+      "address": "0xE2f351EE66e83A41bad79E45bEDFE451ffBf7199",
+      "name": "TricryptoGHO Convex Deposit",
+      "symbol": "cvxGHOBTCwstE",
+      "decimals": 18
+    },
+    "underlyingToken": {
+      "address": "0x8Cd52ee292313C4D851e71A7064F096504aB3eE9",
+      "name": "TricryptoGHO",
+      "symbol": "GHOBTCwstE",
+      "decimals": 18
+    }
+  },
+  "0x8c97D911BF1f47B7d33334B9dcf197Bfe93c7104": {
+    "protocolToken": {
+      "address": "0x8c97D911BF1f47B7d33334B9dcf197Bfe93c7104",
+      "name": "pUSD-3CRV-A1000 Convex Deposit",
+      "symbol": "cvxpUSD3crv",
+      "decimals": 18
+    },
+    "underlyingToken": {
+      "address": "0x2482DFb5A65D901d137742AB1095f26374509352",
+      "name": "pUSD-3CRV-A1000",
+      "symbol": "pUSD3crv",
+      "decimals": 18
+    }
+  },
+  "0xCef9FA76c26747B341984633dac29E20E7B64aF8": {
+    "protocolToken": {
+      "address": "0xCef9FA76c26747B341984633dac29E20E7B64aF8",
+      "name": "xETH/pxETH Convex Deposit",
+      "symbol": "cvxxETHpxETH",
+      "decimals": 18
+    },
+    "underlyingToken": {
+      "address": "0x3C91EAeac42DfaEad5F356167c52837e443b9f94",
+      "name": "xETH/pxETH",
+      "symbol": "xETHpxETH",
+      "decimals": 18
+    }
+  },
+  "0x359589fb4fc290009c3a0B10a232610e9E0A310B": {
+    "protocolToken": {
+      "address": "0x359589fb4fc290009c3a0B10a232610e9E0A310B",
+      "name": "Curve.fi Factory Crypto Pool: ETH+/pxETH Convex Deposit",
+      "symbol": "cvxETH+pxETH-f",
+      "decimals": 18
+    },
+    "underlyingToken": {
+      "address": "0x982bcd444C9445c15CCe3eca506ef01E8348Fe5D",
+      "name": "Curve.fi Factory Crypto Pool: ETH+/pxETH",
+      "symbol": "ETH+pxETH-f",
+      "decimals": 18
+    }
+  },
+  "0x1C9427B79093Aacc5BEe197Bf32aB72403992371": {
+    "protocolToken": {
+      "address": "0x1C9427B79093Aacc5BEe197Bf32aB72403992371",
+      "name": "Curve.fi Factory Crypto Pool: pxETH/mkUSD Convex Deposit",
+      "symbol": "cvxpxETHmkUSD-f",
+      "decimals": 18
+    },
+    "underlyingToken": {
+      "address": "0x6ade6971Ca3d90990C30d39c78b0534C7166e07b",
+      "name": "Curve.fi Factory Crypto Pool: pxETH/mkUSD",
+      "symbol": "pxETHmkUSD-f",
       "decimals": 18
     }
   }

--- a/src/adapters/convex/products/rewards/convexRewardsAdapter.ts
+++ b/src/adapters/convex/products/rewards/convexRewardsAdapter.ts
@@ -319,7 +319,15 @@ export class ConvexRewardsAdapter
     const poolMetadata = (await this.buildMetadata())[protocolTokenAddress]
 
     if (!poolMetadata) {
-      logger.error({ protocolTokenAddress }, 'Protocol token pool not found')
+      logger.error(
+        {
+          protocolTokenAddress,
+          protocol: this.protocolId,
+          chainId: this.chainId,
+          product: this.productId,
+        },
+        'Protocol token pool not found',
+      )
       throw new Error('Protocol token pool not found')
     }
 

--- a/src/adapters/convex/products/rewards/metadata/ethereum.protocol-token.json
+++ b/src/adapters/convex/products/rewards/metadata/ethereum.protocol-token.json
@@ -4086,5 +4086,145 @@
       "symbol": "CRV",
       "decimals": 18
     }
+  },
+  "0xBdeb10ed4FE95a2f79A9D60F9C16206BfcBA6Ef7": {
+    "protocolToken": {
+      "address": "0xBdeb10ed4FE95a2f79A9D60F9C16206BfcBA6Ef7",
+      "name": "eUSD/mkUSD Convex Deposit",
+      "symbol": "cvxeUSDmkUSD",
+      "decimals": 18
+    },
+    "underlyingToken": {
+      "address": "0xD533a949740bb3306d119CC777fa900bA034cd52",
+      "name": "Curve DAO Token",
+      "symbol": "CRV",
+      "decimals": 18
+    }
+  },
+  "0x01099Fe2c82C6F5Dc7485697fBC234f034E3329A": {
+    "protocolToken": {
+      "address": "0x01099Fe2c82C6F5Dc7485697fBC234f034E3329A",
+      "name": "eUSD/crvUSD Convex Deposit",
+      "symbol": "cvxeUSDcrvUSD",
+      "decimals": 18
+    },
+    "underlyingToken": {
+      "address": "0xD533a949740bb3306d119CC777fa900bA034cd52",
+      "name": "Curve DAO Token",
+      "symbol": "CRV",
+      "decimals": 18
+    }
+  },
+  "0xc72dA58342e6bE07858B12c0AFE3Db9aF098b849": {
+    "protocolToken": {
+      "address": "0xc72dA58342e6bE07858B12c0AFE3Db9aF098b849",
+      "name": "weeTH/rswETH Convex Deposit",
+      "symbol": "cvxweeTH/rswE",
+      "decimals": 18
+    },
+    "underlyingToken": {
+      "address": "0xD533a949740bb3306d119CC777fa900bA034cd52",
+      "name": "Curve DAO Token",
+      "symbol": "CRV",
+      "decimals": 18
+    }
+  },
+  "0x5FBA4b8417d239AF93ce194c6F25A1D29020A799": {
+    "protocolToken": {
+      "address": "0x5FBA4b8417d239AF93ce194c6F25A1D29020A799",
+      "name": "rswETH/ETH Convex Deposit",
+      "symbol": "cvxrswETH/ETH",
+      "decimals": 18
+    },
+    "underlyingToken": {
+      "address": "0xD533a949740bb3306d119CC777fa900bA034cd52",
+      "name": "Curve DAO Token",
+      "symbol": "CRV",
+      "decimals": 18
+    }
+  },
+  "0xbf93ffB9C681052b810E300B38F59676a78f16b3": {
+    "protocolToken": {
+      "address": "0xbf93ffB9C681052b810E300B38F59676a78f16b3",
+      "name": "BobrCRV/CRV/crvUSD Convex Deposit",
+      "symbol": "cvxBobrCRV",
+      "decimals": 18
+    },
+    "underlyingToken": {
+      "address": "0xD533a949740bb3306d119CC777fa900bA034cd52",
+      "name": "Curve DAO Token",
+      "symbol": "CRV",
+      "decimals": 18
+    }
+  },
+  "0x923D3C32f870E7953dd4020D0585D6419C44e4Ca": {
+    "protocolToken": {
+      "address": "0x923D3C32f870E7953dd4020D0585D6419C44e4Ca",
+      "name": "TricryptoGHO Convex Deposit",
+      "symbol": "cvxGHOBTCwstE",
+      "decimals": 18
+    },
+    "underlyingToken": {
+      "address": "0xD533a949740bb3306d119CC777fa900bA034cd52",
+      "name": "Curve DAO Token",
+      "symbol": "CRV",
+      "decimals": 18
+    }
+  },
+  "0x4C204392a9E4d5f8390541971B59FC95B24782b5": {
+    "protocolToken": {
+      "address": "0x4C204392a9E4d5f8390541971B59FC95B24782b5",
+      "name": "pUSD-3CRV-A1000 Convex Deposit",
+      "symbol": "cvxpUSD3crv",
+      "decimals": 18
+    },
+    "underlyingToken": {
+      "address": "0xD533a949740bb3306d119CC777fa900bA034cd52",
+      "name": "Curve DAO Token",
+      "symbol": "CRV",
+      "decimals": 18
+    }
+  },
+  "0xc30946E3c09D86c3546e11286BC2779b2a40A972": {
+    "protocolToken": {
+      "address": "0xc30946E3c09D86c3546e11286BC2779b2a40A972",
+      "name": "xETH/pxETH Convex Deposit",
+      "symbol": "cvxxETHpxETH",
+      "decimals": 18
+    },
+    "underlyingToken": {
+      "address": "0xD533a949740bb3306d119CC777fa900bA034cd52",
+      "name": "Curve DAO Token",
+      "symbol": "CRV",
+      "decimals": 18
+    }
+  },
+  "0x29aB65DB26116249b0D30c2349C1C7Fa56648203": {
+    "protocolToken": {
+      "address": "0x29aB65DB26116249b0D30c2349C1C7Fa56648203",
+      "name": "Curve.fi Factory Crypto Pool: ETH+/pxETH Convex Deposit",
+      "symbol": "cvxETH+pxETH-f",
+      "decimals": 18
+    },
+    "underlyingToken": {
+      "address": "0xD533a949740bb3306d119CC777fa900bA034cd52",
+      "name": "Curve DAO Token",
+      "symbol": "CRV",
+      "decimals": 18
+    }
+  },
+  "0x484A34B0154A97B09828736888b95bb298F3a8DF": {
+    "protocolToken": {
+      "address": "0x484A34B0154A97B09828736888b95bb298F3a8DF",
+      "name": "Curve.fi Factory Crypto Pool: pxETH/mkUSD Convex Deposit",
+      "symbol": "cvxpxETHmkUSD-f",
+      "decimals": 18
+    },
+    "underlyingToken": {
+      "address": "0xD533a949740bb3306d119CC777fa900bA034cd52",
+      "name": "Curve DAO Token",
+      "symbol": "CRV",
+      "decimals": 18
+    }
   }
 }

--- a/src/adapters/convex/products/staking/convexStakingAdapter.ts
+++ b/src/adapters/convex/products/staking/convexStakingAdapter.ts
@@ -187,7 +187,15 @@ export class ConvexStakingAdapter
     const poolMetadata = (await this.buildMetadata())[protocolTokenAddress]
 
     if (!poolMetadata) {
-      logger.error({ protocolTokenAddress }, 'Protocol token pool not found')
+      logger.error(
+        {
+          protocolTokenAddress,
+          protocol: this.protocolId,
+          chainId: this.chainId,
+          product: this.productId,
+        },
+        'Protocol token pool not found',
+      )
       throw new Error('Protocol token pool not found')
     }
 

--- a/src/adapters/convex/products/staking/metadata/ethereum.protocol-token.json
+++ b/src/adapters/convex/products/staking/metadata/ethereum.protocol-token.json
@@ -8,8 +8,8 @@
     },
     "underlyingToken": {
       "address": "0x845838DF265Dcd2c412A1Dc9e959c7d08537f8a2",
-      "name": "Curve.fi cDAI/cUSDC",
-      "symbol": "cDAI+cUSDC",
+      "name": "LP-cCurve",
+      "symbol": "CCURVE",
       "decimals": 18
     }
   },
@@ -36,8 +36,8 @@
     },
     "underlyingToken": {
       "address": "0xdF5e0e81Dff6FAF3A7e52BA697820c5e32D806A8",
-      "name": "Curve.fi yDAI/yUSDC/yUSDT/yTUSD",
-      "symbol": "yDAI+yUSDC+yUSDT+yTUSD",
+      "name": "LP yCurve",
+      "symbol": "YCURVE",
       "decimals": 18
     }
   },
@@ -50,8 +50,8 @@
     },
     "underlyingToken": {
       "address": "0x3B3Ac5386837Dc563660FB6a0937DFAa5924333B",
-      "name": "Curve.fi yDAI/yUSDC/yUSDT/yBUSD",
-      "symbol": "yDAI+yUSDC+yUSDT+yBUSD",
+      "name": "LP-bCurve",
+      "symbol": "BCURVE",
       "decimals": 18
     }
   },
@@ -64,8 +64,8 @@
     },
     "underlyingToken": {
       "address": "0xC25a3A3b969415c80451098fa907EC722572917F",
-      "name": "Curve.fi DAI/USDC/USDT/sUSD",
-      "symbol": "crvPlain3andSUSD",
+      "name": "LP sCurve",
+      "symbol": "SCURVE",
       "decimals": 18
     }
   },
@@ -78,8 +78,8 @@
     },
     "underlyingToken": {
       "address": "0xD905e2eaeBe188fc92179b6350807D8bd91Db0D8",
-      "name": "Curve.fi DAI/USDC/USDT/PAX",
-      "symbol": "ypaxCrv",
+      "name": "LP-paxCurve",
+      "symbol": "PAXCURVE",
       "decimals": 18
     }
   },
@@ -92,8 +92,8 @@
     },
     "underlyingToken": {
       "address": "0x49849C98ae39Fff122806C06791Fa73784FB3675",
-      "name": "Curve.fi renBTC/wBTC",
-      "symbol": "crvRenWBTC",
+      "name": "LP renBTC Curve",
+      "symbol": "RENBTCCURVE",
       "decimals": 18
     }
   },
@@ -106,8 +106,8 @@
     },
     "underlyingToken": {
       "address": "0x075b1bb99792c9E1041bA13afEf80C91a1e70fB3",
-      "name": "Curve.fi renBTC/wBTC/sBTC",
-      "symbol": "crvRenWSBTC",
+      "name": "Curve fi renBTC wBTC sBTC",
+      "symbol": "CRVRENWSBTC",
       "decimals": 18
     }
   },
@@ -134,8 +134,8 @@
     },
     "underlyingToken": {
       "address": "0x6c3F90f043a72FA612cbac8115EE7e52BDe6E490",
-      "name": "Curve.fi DAI/USDC/USDT",
-      "symbol": "3Crv",
+      "name": "LP 3pool Curve",
+      "symbol": "3CRV",
       "decimals": 18
     }
   },
@@ -470,8 +470,8 @@
     },
     "underlyingToken": {
       "address": "0xEd279fDD11cA84bEef15AF5D39BB4d4bEE23F0cA",
-      "name": "Curve.fi Factory USD Metapool: Liquity",
-      "symbol": "LUSD3CRV-f",
+      "name": "LUSD3CRV f",
+      "symbol": "LUSD3CRV",
       "decimals": 18
     }
   },
@@ -1408,8 +1408,8 @@
     },
     "underlyingToken": {
       "address": "0x3175Df0976dFA876431C2E9eE6Bc45b65d3473CC",
-      "name": "Curve.fi FRAX/USDC",
-      "symbol": "crvFRAX",
+      "name": "Curve fi FRAX USDC",
+      "symbol": "CRVFRAX",
       "decimals": 18
     }
   },
@@ -4084,6 +4084,146 @@
       "address": "0x678053c553B963f83798b54D7F69deC086D527BA",
       "name": "crvUSD/stUSDT",
       "symbol": "crvstUSDT",
+      "decimals": 18
+    }
+  },
+  "0xBdeb10ed4FE95a2f79A9D60F9C16206BfcBA6Ef7": {
+    "protocolToken": {
+      "address": "0xBdeb10ed4FE95a2f79A9D60F9C16206BfcBA6Ef7",
+      "name": "eUSD/mkUSD Convex Deposit",
+      "symbol": "cvxeUSDmkUSD",
+      "decimals": 18
+    },
+    "underlyingToken": {
+      "address": "0xc37c0E88551Ed383c1aBEDc6628a5579071BF56f",
+      "name": "eUSD/mkUSD",
+      "symbol": "eUSDmkUSD",
+      "decimals": 18
+    }
+  },
+  "0x01099Fe2c82C6F5Dc7485697fBC234f034E3329A": {
+    "protocolToken": {
+      "address": "0x01099Fe2c82C6F5Dc7485697fBC234f034E3329A",
+      "name": "eUSD/crvUSD Convex Deposit",
+      "symbol": "cvxeUSDcrvUSD",
+      "decimals": 18
+    },
+    "underlyingToken": {
+      "address": "0x91285c4fC766ffF6F3acAfeEC7a0423275257faE",
+      "name": "eUSD/crvUSD",
+      "symbol": "eUSDcrvUSD",
+      "decimals": 18
+    }
+  },
+  "0xc72dA58342e6bE07858B12c0AFE3Db9aF098b849": {
+    "protocolToken": {
+      "address": "0xc72dA58342e6bE07858B12c0AFE3Db9aF098b849",
+      "name": "weeTH/rswETH Convex Deposit",
+      "symbol": "cvxweeTH/rswE",
+      "decimals": 18
+    },
+    "underlyingToken": {
+      "address": "0x278cfB6f06B1EFc09d34fC7127d6060C61d629Db",
+      "name": "weeTH/rswETH",
+      "symbol": "weeTH/rswE",
+      "decimals": 18
+    }
+  },
+  "0x5FBA4b8417d239AF93ce194c6F25A1D29020A799": {
+    "protocolToken": {
+      "address": "0x5FBA4b8417d239AF93ce194c6F25A1D29020A799",
+      "name": "rswETH/ETH Convex Deposit",
+      "symbol": "cvxrswETH/ETH",
+      "decimals": 18
+    },
+    "underlyingToken": {
+      "address": "0xeE04382c4cA6c450213923fE0f0daB19b0ff3939",
+      "name": "rswETH/ETH",
+      "symbol": "rswETH/ETH",
+      "decimals": 18
+    }
+  },
+  "0xbf93ffB9C681052b810E300B38F59676a78f16b3": {
+    "protocolToken": {
+      "address": "0xbf93ffB9C681052b810E300B38F59676a78f16b3",
+      "name": "BobrCRV/CRV/crvUSD Convex Deposit",
+      "symbol": "cvxBobrCRV",
+      "decimals": 18
+    },
+    "underlyingToken": {
+      "address": "0x9FeE65D5A627e73212989c8BbEdC5Fa5Cae3821F",
+      "name": "BobrCRV/CRV/crvUSD",
+      "symbol": "BobrCRV",
+      "decimals": 18
+    }
+  },
+  "0x923D3C32f870E7953dd4020D0585D6419C44e4Ca": {
+    "protocolToken": {
+      "address": "0x923D3C32f870E7953dd4020D0585D6419C44e4Ca",
+      "name": "TricryptoGHO Convex Deposit",
+      "symbol": "cvxGHOBTCwstE",
+      "decimals": 18
+    },
+    "underlyingToken": {
+      "address": "0x8Cd52ee292313C4D851e71A7064F096504aB3eE9",
+      "name": "TricryptoGHO",
+      "symbol": "GHOBTCwstE",
+      "decimals": 18
+    }
+  },
+  "0x4C204392a9E4d5f8390541971B59FC95B24782b5": {
+    "protocolToken": {
+      "address": "0x4C204392a9E4d5f8390541971B59FC95B24782b5",
+      "name": "pUSD-3CRV-A1000 Convex Deposit",
+      "symbol": "cvxpUSD3crv",
+      "decimals": 18
+    },
+    "underlyingToken": {
+      "address": "0x2482DFb5A65D901d137742AB1095f26374509352",
+      "name": "pUSD-3CRV-A1000",
+      "symbol": "pUSD3crv",
+      "decimals": 18
+    }
+  },
+  "0xc30946E3c09D86c3546e11286BC2779b2a40A972": {
+    "protocolToken": {
+      "address": "0xc30946E3c09D86c3546e11286BC2779b2a40A972",
+      "name": "xETH/pxETH Convex Deposit",
+      "symbol": "cvxxETHpxETH",
+      "decimals": 18
+    },
+    "underlyingToken": {
+      "address": "0x3C91EAeac42DfaEad5F356167c52837e443b9f94",
+      "name": "xETH/pxETH",
+      "symbol": "xETHpxETH",
+      "decimals": 18
+    }
+  },
+  "0x29aB65DB26116249b0D30c2349C1C7Fa56648203": {
+    "protocolToken": {
+      "address": "0x29aB65DB26116249b0D30c2349C1C7Fa56648203",
+      "name": "Curve.fi Factory Crypto Pool: ETH+/pxETH Convex Deposit",
+      "symbol": "cvxETH+pxETH-f",
+      "decimals": 18
+    },
+    "underlyingToken": {
+      "address": "0x982bcd444C9445c15CCe3eca506ef01E8348Fe5D",
+      "name": "Curve.fi Factory Crypto Pool: ETH+/pxETH",
+      "symbol": "ETH+pxETH-f",
+      "decimals": 18
+    }
+  },
+  "0x484A34B0154A97B09828736888b95bb298F3a8DF": {
+    "protocolToken": {
+      "address": "0x484A34B0154A97B09828736888b95bb298F3a8DF",
+      "name": "Curve.fi Factory Crypto Pool: pxETH/mkUSD Convex Deposit",
+      "symbol": "cvxpxETHmkUSD-f",
+      "decimals": 18
+    },
+    "underlyingToken": {
+      "address": "0x6ade6971Ca3d90990C30d39c78b0534C7166e07b",
+      "name": "Curve.fi Factory Crypto Pool: pxETH/mkUSD",
+      "symbol": "pxETHmkUSD-f",
       "decimals": 18
     }
   }

--- a/src/adapters/convex/tests/snapshots/ethereum.deposits.json
+++ b/src/adapters/convex/tests/snapshots/ethereum.deposits.json
@@ -21,8 +21,8 @@
         "tokens": [
           {
             "address": "0x6c3F90f043a72FA612cbac8115EE7e52BDe6E490",
-            "name": "Curve.fi DAI/USDC/USDT",
-            "symbol": "3Crv",
+            "name": "LP 3pool Curve",
+            "symbol": "3CRV",
             "decimals": 18,
             "balanceRaw": "20000000000000000000n",
             "type": "underlying",

--- a/src/adapters/convex/tests/snapshots/ethereum.positions.2.json
+++ b/src/adapters/convex/tests/snapshots/ethereum.positions.2.json
@@ -305,7 +305,7 @@
             },
             {
               "address": "0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B",
-              "name": "Convex Token",
+              "name": "Convex Finance",
               "symbol": "CVX",
               "decimals": 18,
               "balanceRaw": "31457158657542342582n",
@@ -316,8 +316,8 @@
             },
             {
               "address": "0x6c3F90f043a72FA612cbac8115EE7e52BDe6E490",
-              "name": "Curve.fi DAI/USDC/USDT",
-              "symbol": "3Crv",
+              "name": "LP 3pool Curve",
+              "symbol": "3CRV",
               "decimals": 18,
               "balanceRaw": "0n",
               "type": "underlying-claimable",

--- a/src/adapters/convex/tests/snapshots/ethereum.positions.3.json
+++ b/src/adapters/convex/tests/snapshots/ethereum.positions.3.json
@@ -34,8 +34,8 @@
           "tokens": [
             {
               "address": "0x845838DF265Dcd2c412A1Dc9e959c7d08537f8a2",
-              "name": "Curve.fi cDAI/cUSDC",
-              "symbol": "cDAI+cUSDC",
+              "name": "LP-cCurve",
+              "symbol": "CCURVE",
               "decimals": 18,
               "balanceRaw": "128997493050015238077933n",
               "type": "underlying",
@@ -192,7 +192,7 @@
             },
             {
               "address": "0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B",
-              "name": "Convex Token",
+              "name": "Convex Finance",
               "symbol": "CVX",
               "decimals": 18,
               "balanceRaw": "5100813534806061084n",
@@ -203,8 +203,8 @@
             },
             {
               "address": "0x6c3F90f043a72FA612cbac8115EE7e52BDe6E490",
-              "name": "Curve.fi DAI/USDC/USDT",
-              "symbol": "3Crv",
+              "name": "LP 3pool Curve",
+              "symbol": "3CRV",
               "decimals": 18,
               "balanceRaw": "107897204776540558069n",
               "type": "underlying-claimable",

--- a/src/adapters/convex/tests/snapshots/ethereum.positions.json
+++ b/src/adapters/convex/tests/snapshots/ethereum.positions.json
@@ -22,8 +22,8 @@
           "tokens": [
             {
               "address": "0x6c3F90f043a72FA612cbac8115EE7e52BDe6E490",
-              "name": "Curve.fi DAI/USDC/USDT",
-              "symbol": "3Crv",
+              "name": "LP 3pool Curve",
+              "symbol": "3CRV",
               "decimals": 18,
               "balanceRaw": "20000000000000000000n",
               "type": "underlying",
@@ -91,8 +91,8 @@
           "tokens": [
             {
               "address": "0x6c3F90f043a72FA612cbac8115EE7e52BDe6E490",
-              "name": "Curve.fi DAI/USDC/USDT",
-              "symbol": "3Crv",
+              "name": "LP 3pool Curve",
+              "symbol": "3CRV",
               "decimals": 18,
               "balanceRaw": "29004301062047034124n",
               "type": "underlying",

--- a/src/adapters/convex/tests/snapshots/ethereum.profits.cvxcrv-wrapper.json
+++ b/src/adapters/convex/tests/snapshots/ethereum.profits.cvxcrv-wrapper.json
@@ -1,0 +1,227 @@
+{
+  "blockNumber": 18713643,
+  "snapshot": [
+    {
+      "protocolId": "convex",
+      "name": "Convex",
+      "description": "Convex pool adapter",
+      "siteUrl": "https://www.convexfinance.com/",
+      "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B/logo.png",
+      "positionType": "supply",
+      "chainId": 1,
+      "productId": "pool",
+      "success": true,
+      "tokens": [],
+      "fromBlock": 18706497,
+      "toBlock": 18713643
+    },
+    {
+      "protocolId": "convex",
+      "name": "Convex",
+      "description": "Convex pool adapter",
+      "siteUrl": "https://www.convexfinance.com/",
+      "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B/logo.png",
+      "positionType": "supply",
+      "chainId": 1,
+      "productId": "staking",
+      "success": true,
+      "tokens": [],
+      "fromBlock": 18706497,
+      "toBlock": 18713643
+    },
+    {
+      "protocolId": "convex",
+      "name": "Convex",
+      "description": "Convex pool adapter",
+      "siteUrl": "https://www.convexfinance.com/",
+      "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B/logo.png",
+      "positionType": "supply",
+      "chainId": 1,
+      "productId": "cvxcrv-wrapper",
+      "success": true,
+      "tokens": [
+        {
+          "address": "0xaa0C3f5F7DFD688C6E646F66CD2a6B66ACdbE434",
+          "name": "Staked CvxCrv",
+          "symbol": "stkCvxCrv",
+          "decimals": 18,
+          "type": "protocol",
+          "profit": 1.7228626927251014,
+          "performance": 0.009809125958622714,
+          "calculationData": {
+            "withdrawals": 0,
+            "deposits": 0,
+            "startPositionValue": 175.63875721369635,
+            "endPositionValue": 177.36161990642145
+          },
+          "rawValues": {
+            "rawEndPositionValues": [
+              {
+                "address": "0xaa0C3f5F7DFD688C6E646F66CD2a6B66ACdbE434",
+                "name": "Staked CvxCrv",
+                "symbol": "stkCvxCrv",
+                "decimals": 18,
+                "balanceRaw": "6399036031308907252576n",
+                "type": "protocol",
+                "tokens": [
+                  {
+                    "address": "0xD533a949740bb3306d119CC777fa900bA034cd52",
+                    "name": "Curve DAO Token",
+                    "symbol": "CRV",
+                    "decimals": 18,
+                    "balanceRaw": "42571127366382811945n",
+                    "type": "underlying-claimable",
+                    "balance": 42.57112736638281,
+                    "price": 0.5895065199962559,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xD533a949740bb3306d119CC777fa900bA034cd52/logo.png"
+                  },
+                  {
+                    "address": "0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B",
+                    "name": "Convex Finance",
+                    "symbol": "CVX",
+                    "decimals": 18,
+                    "balanceRaw": "5100813534806061084n",
+                    "type": "underlying-claimable",
+                    "balance": 5.100813534806061,
+                    "price": 3.8257813655315345,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B/logo.png"
+                  },
+                  {
+                    "address": "0x6c3F90f043a72FA612cbac8115EE7e52BDe6E490",
+                    "name": "LP 3pool Curve",
+                    "symbol": "3CRV",
+                    "decimals": 18,
+                    "balanceRaw": "128166105566414662840n",
+                    "type": "underlying-claimable",
+                    "tokens": [
+                      {
+                        "address": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+                        "name": "Dai Stablecoin",
+                        "symbol": "DAI",
+                        "decimals": 18,
+                        "type": "underlying",
+                        "balanceRaw": "52708557100541733295n",
+                        "balance": 52.70855710054173,
+                        "price": 1.0017063368720214,
+                        "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png"
+                      },
+                      {
+                        "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                        "name": "USD Coin",
+                        "symbol": "USDC",
+                        "decimals": 6,
+                        "type": "underlying",
+                        "balanceRaw": "50213045n",
+                        "balance": 50.213045,
+                        "price": 1.0161023818686534,
+                        "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
+                      },
+                      {
+                        "address": "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+                        "name": "Tether USD",
+                        "symbol": "USDT",
+                        "decimals": 6,
+                        "type": "underlying",
+                        "balanceRaw": "28868902n",
+                        "balance": 28.868902,
+                        "price": 1.002150172163263,
+                        "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdAC17F958D2ee523a2206206994597C13D831ec7/logo.png"
+                      }
+                    ],
+                    "balance": 128.16610556641467,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6c3F90f043a72FA612cbac8115EE7e52BDe6E490/logo.png"
+                  }
+                ],
+                "balance": 6399.036031308908
+              }
+            ],
+            "rawStartPositionValues": [
+              {
+                "address": "0xaa0C3f5F7DFD688C6E646F66CD2a6B66ACdbE434",
+                "name": "Staked CvxCrv",
+                "symbol": "stkCvxCrv",
+                "decimals": 18,
+                "balanceRaw": "6399036031308907252576n",
+                "type": "protocol",
+                "tokens": [
+                  {
+                    "address": "0xD533a949740bb3306d119CC777fa900bA034cd52",
+                    "name": "Curve DAO Token",
+                    "symbol": "CRV",
+                    "decimals": 18,
+                    "balanceRaw": "42571127366382811945n",
+                    "type": "underlying-claimable",
+                    "balance": 42.57112736638281,
+                    "price": 0.5945658148847325,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xD533a949740bb3306d119CC777fa900bA034cd52/logo.png"
+                  },
+                  {
+                    "address": "0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B",
+                    "name": "Convex Finance",
+                    "symbol": "CVX",
+                    "decimals": 18,
+                    "balanceRaw": "5100813534806061084n",
+                    "type": "underlying-claimable",
+                    "balance": 5.100813534806061,
+                    "price": 3.8384903603204203,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B/logo.png"
+                  },
+                  {
+                    "address": "0x6c3F90f043a72FA612cbac8115EE7e52BDe6E490",
+                    "name": "LP 3pool Curve",
+                    "symbol": "3CRV",
+                    "decimals": 18,
+                    "balanceRaw": "126234298727985746240n",
+                    "type": "underlying-claimable",
+                    "tokens": [
+                      {
+                        "address": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+                        "name": "Dai Stablecoin",
+                        "symbol": "DAI",
+                        "decimals": 18,
+                        "type": "underlying",
+                        "balanceRaw": "51650271442433807119n",
+                        "balance": 51.650271442433805,
+                        "price": 1.0022479881129192,
+                        "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png"
+                      },
+                      {
+                        "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                        "name": "USD Coin",
+                        "symbol": "USDC",
+                        "decimals": 6,
+                        "type": "underlying",
+                        "balanceRaw": "52000957n",
+                        "balance": 52.000957,
+                        "price": 1.0143365322953304,
+                        "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
+                      },
+                      {
+                        "address": "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+                        "name": "Tether USD",
+                        "symbol": "USDT",
+                        "decimals": 6,
+                        "type": "underlying",
+                        "balanceRaw": "26152464n",
+                        "balance": 26.152464,
+                        "price": 1.0031615208154834,
+                        "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdAC17F958D2ee523a2206206994597C13D831ec7/logo.png"
+                      }
+                    ],
+                    "balance": 126.23429872798575,
+                    "iconUrl": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6c3F90f043a72FA612cbac8115EE7e52BDe6E490/logo.png"
+                  }
+                ],
+                "balance": 6399.036031308908
+              }
+            ],
+            "rawWithdrawals": [],
+            "rawDeposits": []
+          }
+        }
+      ],
+      "fromBlock": 18706497,
+      "toBlock": 18713643
+    }
+  ]
+}

--- a/src/adapters/convex/tests/snapshots/ethereum.profits.json
+++ b/src/adapters/convex/tests/snapshots/ethereum.profits.json
@@ -77,13 +77,13 @@
           "symbol": "stkCvxCrv",
           "decimals": 18,
           "type": "protocol",
-          "profit": 2.00306879243945,
-          "performance": 0.015320072540823466,
+          "profit": 1.7228626927251014,
+          "performance": 0.009809125958622714,
           "calculationData": {
             "withdrawals": 0,
             "deposits": 0,
-            "startPositionValue": 130.74799659739622,
-            "endPositionValue": 132.75106538983567
+            "startPositionValue": 175.63875721369635,
+            "endPositionValue": 177.36161990642145
           }
         }
       ],

--- a/src/adapters/convex/tests/snapshots/ethereum.profits.json
+++ b/src/adapters/convex/tests/snapshots/ethereum.profits.json
@@ -24,13 +24,41 @@
       "positionType": "supply",
       "chainId": 1,
       "productId": "staking",
-      "success": false,
-      "error": {
-        "message": "Protocol token pool not found",
-        "details": {
-          "name": "Error"
+      "success": true,
+      "tokens": [
+        {
+          "address": "0xf34DFF761145FF0B05e917811d488B441F33a968",
+          "name": "Curve.fi cDAI/cUSDC Convex Deposit",
+          "symbol": "cvxcDAI+cUSDC",
+          "decimals": 18,
+          "type": "protocol",
+          "profit": 706198.5526794195,
+          "performance": 0.0017408823849241644,
+          "calculationData": {
+            "withdrawals": 0,
+            "deposits": 0,
+            "startPositionValue": 405655522.04733384,
+            "endPositionValue": 406361720.60001326
+          }
+        },
+        {
+          "address": "0x44D8FaB7CD8b7877D5F79974c2F501aF6E65AbBA",
+          "name": "Curve.fi Factory Plain Pool: crvUSD/USDC Convex Deposit",
+          "symbol": "cvxcrvUSDUSDC-f",
+          "decimals": 18,
+          "type": "protocol",
+          "profit": -61.67404994936442,
+          "performance": -0.0024720462305284413,
+          "calculationData": {
+            "withdrawals": 0,
+            "deposits": 0,
+            "startPositionValue": 24948.582752103528,
+            "endPositionValue": 24886.908702154164
+          }
         }
-      }
+      ],
+      "fromBlock": 18706497,
+      "toBlock": 18713643
     },
     {
       "protocolId": "convex",
@@ -49,13 +77,13 @@
           "symbol": "stkCvxCrv",
           "decimals": 18,
           "type": "protocol",
-          "profit": 1.7228626927251014,
-          "performance": 0.009809125958622714,
+          "profit": 2.00306879243945,
+          "performance": 0.015320072540823466,
           "calculationData": {
             "withdrawals": 0,
             "deposits": 0,
-            "startPositionValue": 175.63875721369635,
-            "endPositionValue": 177.36161990642145
+            "startPositionValue": 130.74799659739622,
+            "endPositionValue": 132.75106538983567
           }
         }
       ],

--- a/src/adapters/convex/tests/snapshots/ethereum.withdrawals.3.json
+++ b/src/adapters/convex/tests/snapshots/ethereum.withdrawals.3.json
@@ -43,7 +43,7 @@
         "tokens": [
           {
             "address": "0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B",
-            "name": "Convex Token",
+            "name": "Convex Finance",
             "symbol": "CVX",
             "decimals": 18,
             "balanceRaw": "390488348790686281236n",
@@ -65,8 +65,8 @@
         "tokens": [
           {
             "address": "0x6c3F90f043a72FA612cbac8115EE7e52BDe6E490",
-            "name": "Curve.fi DAI/USDC/USDT",
-            "symbol": "3Crv",
+            "name": "LP 3pool Curve",
+            "symbol": "3CRV",
             "decimals": 18,
             "balanceRaw": "1419767977106002257650n",
             "type": "underlying",

--- a/src/adapters/convex/tests/testCases.ts
+++ b/src/adapters/convex/tests/testCases.ts
@@ -85,4 +85,16 @@ export const testCases: TestCase[] = [
     },
     blockNumber: 18713643,
   },
+  {
+    chainId: Chain.Ethereum,
+    method: 'profits',
+    key: 'cvxcrv-wrapper',
+    input: {
+      userAddress: '0x8654a995426e775f3ef023cd6e1b5681e774ffa1',
+      timePeriod: TimePeriod.oneDay,
+      filterProtocolTokens: ['0xaa0C3f5F7DFD688C6E646F66CD2a6B66ACdbE434'],
+      includeRawValues: true,
+    },
+    blockNumber: 18713643,
+  },
 ]

--- a/src/adapters/curve/products/pool/curvePoolAdapter.ts
+++ b/src/adapters/curve/products/pool/curvePoolAdapter.ts
@@ -230,7 +230,15 @@ export class CurvePoolAdapter
     const poolMetadata = (await this.buildMetadata())[protocolTokenAddress]
 
     if (!poolMetadata) {
-      logger.error({ protocolTokenAddress }, 'Protocol token pool not found')
+      logger.error(
+        {
+          protocolTokenAddress,
+          protocol: this.protocolId,
+          chainId: this.chainId,
+          product: this.productId,
+        },
+        'Protocol token pool not found',
+      )
       throw new Error('Protocol token pool not found')
     }
 

--- a/src/adapters/curve/products/staking/curveStakingAdapter.ts
+++ b/src/adapters/curve/products/staking/curveStakingAdapter.ts
@@ -253,7 +253,15 @@ export class CurveStakingAdapter
     const poolMetadata = (await this.buildMetadata())[protocolTokenAddress]
 
     if (!poolMetadata) {
-      logger.error({ protocolTokenAddress }, 'Protocol token pool not found')
+      logger.error(
+        {
+          protocolTokenAddress,
+          protocol: this.protocolId,
+          chainId: this.chainId,
+          product: this.productId,
+        },
+        'Protocol token pool not found',
+      )
       throw new Error('Protocol token pool not found')
     }
 

--- a/src/adapters/iziswap/tests/snapshots/linea.profits.profit-1.json
+++ b/src/adapters/iziswap/tests/snapshots/linea.profits.profit-1.json
@@ -10,13 +10,46 @@
       "positionType": "supply",
       "chainId": 59144,
       "productId": "iziswap",
-      "success": false,
-      "error": {
-        "message": "Unable to calculate profits, missing USD price for token position 0x176211869cA2b568f2A7D4EE941E073a821EE1ff",
-        "details": {
-          "name": "Error"
+      "success": true,
+      "tokens": [
+        {
+          "address": "0x1CB60033F61e4fc171c963f0d2d3F63Ece24319c",
+          "name": "USDC / WETH - 3000",
+          "symbol": "USDC / WETH - 3000",
+          "decimals": 18,
+          "tokenId": "20000",
+          "type": "protocol",
+          "profit": 0,
+          "performance": 0,
+          "calculationData": {
+            "withdrawals": 0,
+            "deposits": 0,
+            "startPositionValue": 0,
+            "endPositionValue": 0,
+            "hasTokensWithoutUSDPrices": true,
+            "tokensWithoutUSDPrices": [
+              {
+                "address": "0xe5D7C2a44FfDDf6b295A15c148167daaAf5Cf34f",
+                "name": "Wrapped Ether",
+                "symbol": "WETH",
+                "decimals": 18,
+                "balanceRaw": "12783946682151n",
+                "type": "underlying-claimable"
+              },
+              {
+                "address": "0xe5D7C2a44FfDDf6b295A15c148167daaAf5Cf34f",
+                "name": "Wrapped Ether",
+                "symbol": "WETH",
+                "decimals": 18,
+                "balanceRaw": "14566802396821n",
+                "type": "underlying-claimable"
+              }
+            ]
+          }
         }
-      }
+      ],
+      "fromBlock": 1098124,
+      "toBlock": 1105311
     }
   ]
 }

--- a/src/adapters/iziswap/tests/snapshots/linea.profits.profit-2.json
+++ b/src/adapters/iziswap/tests/snapshots/linea.profits.profit-2.json
@@ -10,13 +10,46 @@
       "positionType": "supply",
       "chainId": 59144,
       "productId": "iziswap",
-      "success": false,
-      "error": {
-        "message": "Unable to calculate profits, missing USD price for token position 0x176211869cA2b568f2A7D4EE941E073a821EE1ff",
-        "details": {
-          "name": "Error"
+      "success": true,
+      "tokens": [
+        {
+          "address": "0x1CB60033F61e4fc171c963f0d2d3F63Ece24319c",
+          "name": "USDC / LAB - 10000",
+          "symbol": "USDC / LAB - 10000",
+          "decimals": 18,
+          "tokenId": "20001",
+          "type": "protocol",
+          "profit": 0,
+          "performance": 0,
+          "calculationData": {
+            "withdrawals": 0,
+            "deposits": 0,
+            "startPositionValue": 0,
+            "endPositionValue": 0,
+            "hasTokensWithoutUSDPrices": true,
+            "tokensWithoutUSDPrices": [
+              {
+                "address": "0xB97F21D1f2508fF5c73E7B5AF02847640B1ff75d",
+                "name": "LineaBank Token",
+                "symbol": "LAB",
+                "decimals": 18,
+                "balanceRaw": "286768941192425743n",
+                "type": "underlying-claimable"
+              },
+              {
+                "address": "0xB97F21D1f2508fF5c73E7B5AF02847640B1ff75d",
+                "name": "LineaBank Token",
+                "symbol": "LAB",
+                "decimals": 18,
+                "balanceRaw": "303946457585683209n",
+                "type": "underlying-claimable"
+              }
+            ]
+          }
         }
-      }
+      ],
+      "fromBlock": 1098124,
+      "toBlock": 1105311
     }
   ]
 }

--- a/src/adapters/mendi-finance/products/borrow/mendiFinanceBorrowAdapter.ts
+++ b/src/adapters/mendi-finance/products/borrow/mendiFinanceBorrowAdapter.ts
@@ -215,7 +215,15 @@ export class MendiFinanceBorrowAdapter
     const poolMetadata = (await this.buildMetadata())[protocolTokenAddress]
 
     if (!poolMetadata) {
-      logger.error({ protocolTokenAddress }, 'Protocol token pool not found')
+      logger.error(
+        {
+          protocolTokenAddress,
+          protocol: this.protocolId,
+          chainId: this.chainId,
+          product: this.productId,
+        },
+        'Protocol token pool not found',
+      )
       throw new Error('Protocol token pool not found')
     }
 

--- a/src/adapters/mendi-finance/products/supply/mendiFinanceSupplyAdapter.ts
+++ b/src/adapters/mendi-finance/products/supply/mendiFinanceSupplyAdapter.ts
@@ -256,7 +256,15 @@ export class MendiFinanceSupplyAdapter
     const poolMetadata = (await this.buildMetadata())[protocolTokenAddress]
 
     if (!poolMetadata) {
-      logger.error({ protocolTokenAddress }, 'Protocol token pool not found')
+      logger.error(
+        {
+          protocolTokenAddress,
+          protocol: this.protocolId,
+          chainId: this.chainId,
+          product: this.productId,
+        },
+        'Protocol token pool not found',
+      )
       throw new Error('Protocol token pool not found')
     }
 

--- a/src/adapters/mendi-finance/tests/snapshots/linea.profits.json
+++ b/src/adapters/mendi-finance/tests/snapshots/linea.profits.json
@@ -10,13 +10,147 @@
       "positionType": "supply",
       "chainId": 59144,
       "productId": "supply",
-      "success": false,
-      "error": {
-        "message": "Unable to calculate profits, missing USD price for token position 0x176211869cA2b568f2A7D4EE941E073a821EE1ff",
-        "details": {
-          "name": "Error"
+      "success": true,
+      "tokens": [
+        {
+          "address": "0x333D8b480BDB25eA7Be4Dd87EEB359988CE1b30D",
+          "name": "Mendi USD Coin",
+          "symbol": "meUSDC",
+          "decimals": 8,
+          "type": "protocol",
+          "profit": 0,
+          "performance": 0,
+          "calculationData": {
+            "withdrawals": 0,
+            "deposits": 0,
+            "startPositionValue": 0,
+            "endPositionValue": 0,
+            "hasTokensWithoutUSDPrices": true,
+            "tokensWithoutUSDPrices": [
+              {
+                "address": "0x176211869cA2b568f2A7D4EE941E073a821EE1ff",
+                "name": "USDC",
+                "symbol": "USDC",
+                "decimals": 6,
+                "balanceRaw": "100076520617n",
+                "type": "underlying"
+              },
+              {
+                "address": "0x176211869cA2b568f2A7D4EE941E073a821EE1ff",
+                "name": "USDC",
+                "symbol": "USDC",
+                "decimals": 6,
+                "balanceRaw": "100081014750n",
+                "type": "underlying"
+              }
+            ]
+          }
+        },
+        {
+          "address": "0xf669C3C03D9fdF4339e19214A749E52616300E89",
+          "name": "Mendi USD Tether",
+          "symbol": "meUSDT",
+          "decimals": 8,
+          "type": "protocol",
+          "profit": 0,
+          "performance": 0,
+          "calculationData": {
+            "withdrawals": 0,
+            "deposits": 0,
+            "startPositionValue": 0,
+            "endPositionValue": 0,
+            "hasTokensWithoutUSDPrices": true,
+            "tokensWithoutUSDPrices": [
+              {
+                "address": "0xA219439258ca9da29E9Cc4cE5596924745e12B93",
+                "name": "Tether USD",
+                "symbol": "USDT",
+                "decimals": 6,
+                "balanceRaw": "57151480038n",
+                "type": "underlying"
+              },
+              {
+                "address": "0xA219439258ca9da29E9Cc4cE5596924745e12B93",
+                "name": "Tether USD",
+                "symbol": "USDT",
+                "decimals": 6,
+                "balanceRaw": "57156119173n",
+                "type": "underlying"
+              }
+            ]
+          }
+        },
+        {
+          "address": "0xAd7f33984bed10518012013D4aB0458D37FEE6F3",
+          "name": "Mendi Wrapped Ether",
+          "symbol": "meWETH",
+          "decimals": 8,
+          "type": "protocol",
+          "profit": 0,
+          "performance": 0,
+          "calculationData": {
+            "withdrawals": 0,
+            "deposits": 0,
+            "startPositionValue": 0,
+            "endPositionValue": 0,
+            "hasTokensWithoutUSDPrices": true,
+            "tokensWithoutUSDPrices": [
+              {
+                "address": "0xe5D7C2a44FfDDf6b295A15c148167daaAf5Cf34f",
+                "name": "Wrapped Ether",
+                "symbol": "WETH",
+                "decimals": 18,
+                "balanceRaw": "804919682555621232n",
+                "type": "underlying"
+              },
+              {
+                "address": "0xe5D7C2a44FfDDf6b295A15c148167daaAf5Cf34f",
+                "name": "Wrapped Ether",
+                "symbol": "WETH",
+                "decimals": 18,
+                "balanceRaw": "804997187618819006n",
+                "type": "underlying"
+              }
+            ]
+          }
+        },
+        {
+          "address": "0x9be5e24F05bBAfC28Da814bD59284878b388a40f",
+          "name": "Mendi Wrapped BTC",
+          "symbol": "meWBTC",
+          "decimals": 8,
+          "type": "protocol",
+          "profit": 0,
+          "performance": 0,
+          "calculationData": {
+            "withdrawals": 0,
+            "deposits": 0,
+            "startPositionValue": 0,
+            "endPositionValue": 0,
+            "hasTokensWithoutUSDPrices": true,
+            "tokensWithoutUSDPrices": [
+              {
+                "address": "0x3aAB2285ddcDdaD8edf438C1bAB47e1a9D05a9b4",
+                "name": "Wrapped BTC",
+                "symbol": "WBTC",
+                "decimals": 8,
+                "balanceRaw": "100138397n",
+                "type": "underlying"
+              },
+              {
+                "address": "0x3aAB2285ddcDdaD8edf438C1bAB47e1a9D05a9b4",
+                "name": "Wrapped BTC",
+                "symbol": "WBTC",
+                "decimals": 8,
+                "balanceRaw": "100141929n",
+                "type": "underlying"
+              }
+            ]
+          }
         }
-      }
+      ],
+      "fromBlock": 1590694,
+      "toBlock": 1597881
     },
     {
       "protocolId": "mendi-finance",

--- a/src/adapters/prices-v2/products/usd/priceV2Config.ts
+++ b/src/adapters/prices-v2/products/usd/priceV2Config.ts
@@ -8,6 +8,7 @@ const ETH = {
   decimals: 18,
 }
 
+// details here https://github.com/1inch/spot-price-aggregator
 const OneInchPriceOracleCommon = getAddress(
   '0x0AdDd25a91563696D8567Df78D5A01C9a991F9B8',
 )

--- a/src/adapters/prices-v2/products/usd/pricesV2UsdAdapter.ts
+++ b/src/adapters/prices-v2/products/usd/pricesV2UsdAdapter.ts
@@ -30,6 +30,9 @@ import { nativeTokenAddresses, priceAdapterConfig } from './priceV2Config'
 
 export const USD = 'USD'
 
+// Project details:
+// https://github.com/1inch/spot-price-aggregator
+
 export class PricesV2UsdAdapter implements IProtocolAdapter {
   productId = 'usd'
   protocolId: Protocol
@@ -73,7 +76,7 @@ export class PricesV2UsdAdapter implements IProtocolAdapter {
    * Returning an array of your protocol tokens.
    */
   async getProtocolTokens(): Promise<Erc20Metadata[]> {
-    throw new NotImplementedError()
+    return [{ address: '', name: '', symbol: '', decimals: 0 }]
   }
 
   /**

--- a/src/adapters/prices-v2/tests/snapshots/ethereum.prices.json
+++ b/src/adapters/prices-v2/tests/snapshots/ethereum.prices.json
@@ -1,5 +1,5 @@
 {
-  "blockNumber": 19241265,
+  "blockNumber": 19268163,
   "snapshot": [
     {
       "protocolId": "prices-v2",

--- a/src/adapters/prices-v2/tests/snapshots/ethereum.prices.json
+++ b/src/adapters/prices-v2/tests/snapshots/ethereum.prices.json
@@ -1,5 +1,5 @@
 {
-  "blockNumber": 19268163,
+  "blockNumber": 19269099,
   "snapshot": [
     {
       "protocolId": "prices-v2",

--- a/src/adapters/prices-v2/tests/snapshots/ethereum.prices.json
+++ b/src/adapters/prices-v2/tests/snapshots/ethereum.prices.json
@@ -1,5 +1,5 @@
 {
-  "blockNumber": 19269099,
+  "blockNumber": 19270601,
   "snapshot": [
     {
       "protocolId": "prices-v2",

--- a/src/adapters/prices-v2/tests/snapshots/ethereum.prices.json
+++ b/src/adapters/prices-v2/tests/snapshots/ethereum.prices.json
@@ -1,0 +1,37 @@
+{
+  "blockNumber": 19241265,
+  "snapshot": [
+    {
+      "protocolId": "prices-v2",
+      "name": "PricesV2",
+      "description": "PricesV2 defi adapter",
+      "siteUrl": "https:",
+      "iconUrl": "https://",
+      "positionType": "supply",
+      "chainId": 1,
+      "productId": "usd",
+      "success": true,
+      "tokens": [
+        {
+          "name": "BBS",
+          "decimals": 18,
+          "symbol": "BBS",
+          "address": "0xFe459828c90c0BA4bC8b42F5C5D44F316700B430",
+          "baseRate": 1,
+          "type": "protocol",
+          "tokens": [
+            {
+              "type": "underlying",
+              "underlyingRateRaw": "0n",
+              "decimals": 18,
+              "name": "USD",
+              "symbol": "USD",
+              "address": "USD",
+              "underlyingRate": 0
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/adapters/prices-v2/tests/testCases.ts
+++ b/src/adapters/prices-v2/tests/testCases.ts
@@ -1,19 +1,10 @@
+import { Chain } from '../../../core/constants/chains'
 import type { TestCase } from '../../../types/testCase'
 
 export const testCases: TestCase[] = [
-  // {
-  //   chainId: Chain.Ethereum,
-  //   method: 'positions',
-  //   input: {
-  //     userAddress: '0x6b8Be925ED8277fE4D27820aE4677e76Ebf4c255',
-  //   },
-  // },
-  // {
-  //   chainId: Chain.Ethereum,
-  //   method: 'profits',
-  //   input: {
-  //     userAddress: '0xCEadFdCCd0E8E370D985c49Ed3117b2572243A4a',
-  //     timePeriod: TimePeriod.oneDay,
-  //   },
-  // },
+  {
+    chainId: Chain.Ethereum,
+    method: 'prices',
+    filterProtocolToken: '0xFe459828c90c0BA4bC8b42F5C5D44F316700B430',
+  },
 ]

--- a/src/adapters/stargate/products/pool/stargatePoolAdapter.ts
+++ b/src/adapters/stargate/products/pool/stargatePoolAdapter.ts
@@ -209,7 +209,15 @@ export class StargatePoolAdapter
     const poolMetadata = (await this.buildMetadata())[protocolTokenAddress]
 
     if (!poolMetadata) {
-      logger.error({ protocolTokenAddress }, 'Protocol token pool not found')
+      logger.error(
+        {
+          protocolTokenAddress,
+          protocol: this.protocolId,
+          chainId: this.chainId,
+          product: this.productId,
+        },
+        'Protocol token pool not found',
+      )
       throw new Error('Protocol token pool not found')
     }
 

--- a/src/adapters/syncswap/tests/snapshots/linea.profits.profit-1.json
+++ b/src/adapters/syncswap/tests/snapshots/linea.profits.profit-1.json
@@ -10,13 +10,45 @@
       "positionType": "supply",
       "chainId": 59144,
       "productId": "pool",
-      "success": false,
-      "error": {
-        "message": "Unable to calculate profits, missing USD price for token position 0x7d43AABC515C356145049227CeE54B608342c0ad",
-        "details": {
-          "name": "Error"
+      "success": true,
+      "tokens": [
+        {
+          "address": "0x7f72E0D8e9AbF9133A92322b8B50BD8e0F9dcFCB",
+          "name": "SyncSwap BUSD/WETH Classic LP",
+          "symbol": "BUSD/WETH cSLP",
+          "decimals": 18,
+          "type": "protocol",
+          "profit": 0,
+          "performance": 0,
+          "calculationData": {
+            "withdrawals": 0,
+            "deposits": 0,
+            "startPositionValue": 0,
+            "endPositionValue": 0,
+            "hasTokensWithoutUSDPrices": true,
+            "tokensWithoutUSDPrices": [
+              {
+                "address": "0xe5D7C2a44FfDDf6b295A15c148167daaAf5Cf34f",
+                "name": "Wrapped Ether",
+                "symbol": "WETH",
+                "decimals": 18,
+                "balanceRaw": "3329708785375489n",
+                "type": "underlying"
+              },
+              {
+                "address": "0xe5D7C2a44FfDDf6b295A15c148167daaAf5Cf34f",
+                "name": "Wrapped Ether",
+                "symbol": "WETH",
+                "decimals": 18,
+                "balanceRaw": "3344778385659625n",
+                "type": "underlying"
+              }
+            ]
+          }
         }
-      }
+      ],
+      "fromBlock": 595287,
+      "toBlock": 645596
     }
   ]
 }

--- a/src/adapters/syncswap/tests/snapshots/linea.profits.profit-2.json
+++ b/src/adapters/syncswap/tests/snapshots/linea.profits.profit-2.json
@@ -10,13 +10,79 @@
       "positionType": "supply",
       "chainId": 59144,
       "productId": "pool",
-      "success": false,
-      "error": {
-        "message": "Unable to calculate profits, missing USD price for token position 0xe5D7C2a44FfDDf6b295A15c148167daaAf5Cf34f",
-        "details": {
-          "name": "Error"
+      "success": true,
+      "tokens": [
+        {
+          "address": "0xd71EcE20343233aD9E7ce29bc954b813f41FbDcB",
+          "name": "SyncSwap WETH/BNB Classic LP",
+          "symbol": "WETH/BNB cSLP",
+          "decimals": 18,
+          "type": "protocol",
+          "profit": 0,
+          "performance": 0,
+          "calculationData": {
+            "withdrawals": 0,
+            "deposits": 0,
+            "startPositionValue": 0,
+            "endPositionValue": 0,
+            "hasTokensWithoutUSDPrices": true,
+            "tokensWithoutUSDPrices": [
+              {
+                "address": "0xf5C6825015280CdfD0b56903F9F8B5A2233476F5",
+                "name": "Binance Coin",
+                "symbol": "BNB",
+                "decimals": 18,
+                "balanceRaw": "1535540822295941n",
+                "type": "underlying"
+              },
+              {
+                "address": "0xf5C6825015280CdfD0b56903F9F8B5A2233476F5",
+                "name": "Binance Coin",
+                "symbol": "BNB",
+                "decimals": 18,
+                "balanceRaw": "1555571978668007n",
+                "type": "underlying"
+              }
+            ]
+          }
+        },
+        {
+          "address": "0x46eC4BB184528C3aEE6F1419E11b28A97f33d483",
+          "name": "SyncSwap MATIC/WETH Classic LP",
+          "symbol": "MATIC/WETH cSLP",
+          "decimals": 18,
+          "type": "protocol",
+          "profit": 0,
+          "performance": 0,
+          "calculationData": {
+            "withdrawals": 0,
+            "deposits": 0,
+            "startPositionValue": 0,
+            "endPositionValue": 0,
+            "hasTokensWithoutUSDPrices": true,
+            "tokensWithoutUSDPrices": [
+              {
+                "address": "0xe5D7C2a44FfDDf6b295A15c148167daaAf5Cf34f",
+                "name": "Wrapped Ether",
+                "symbol": "WETH",
+                "decimals": 18,
+                "balanceRaw": "200832333538911n",
+                "type": "underlying"
+              },
+              {
+                "address": "0xe5D7C2a44FfDDf6b295A15c148167daaAf5Cf34f",
+                "name": "Wrapped Ether",
+                "symbol": "WETH",
+                "decimals": 18,
+                "balanceRaw": "199848460387857n",
+                "type": "underlying"
+              }
+            ]
+          }
         }
-      }
+      ],
+      "fromBlock": 497146,
+      "toBlock": 547455
     }
   ]
 }

--- a/src/core/decorators/addClaimableRewards.ts
+++ b/src/core/decorators/addClaimableRewards.ts
@@ -27,25 +27,24 @@ export function AddClaimableRewards({
 
           await Promise.all(
             protocolTokens.map(async (protocolToken) => {
-              try {
-                const [reward] = await rewardAdapter.getPositions({
-                  ...input,
-                  protocolTokenAddresses: [protocolToken.address],
-                })
+              const isSupported = (
+                await rewardAdapter.getProtocolTokens()
+              ).find((token) => token.address == protocolToken.address)
 
-                if (reward && reward.tokens && reward.tokens.length > 0) {
-                  protocolToken.tokens = [
-                    ...(protocolToken.tokens ?? []),
-                    ...reward.tokens,
-                  ]
-                }
-              } catch (error) {
-                if (
-                  (error as Error).message === 'Protocol token pool not found'
-                ) {
-                  return
-                }
-                throw error
+              if (!isSupported) {
+                return
+              }
+
+              const [reward] = await rewardAdapter.getPositions({
+                ...input,
+                protocolTokenAddresses: [protocolToken.address],
+              })
+
+              if (reward && reward.tokens && reward.tokens.length > 0) {
+                protocolToken.tokens = [
+                  ...(protocolToken.tokens ?? []),
+                  ...reward.tokens,
+                ]
               }
             }),
           )

--- a/src/core/decorators/addClaimableRewards.ts
+++ b/src/core/decorators/addClaimableRewards.ts
@@ -33,13 +33,11 @@ export function AddClaimableRewards({
                   protocolTokenAddresses: [protocolToken.address],
                 })
 
-                if (reward) {
-                  if (reward.tokens) {
-                    protocolToken.tokens = [
-                      ...(protocolToken.tokens ?? []),
-                      ...reward.tokens,
-                    ]
-                  }
+                if (reward && reward.tokens && reward.tokens.length > 0) {
+                  protocolToken.tokens = [
+                    ...(protocolToken.tokens ?? []),
+                    ...reward.tokens,
+                  ]
                 }
               } catch (error) {
                 if (

--- a/src/core/decorators/addClaimableRewards.ts
+++ b/src/core/decorators/addClaimableRewards.ts
@@ -27,18 +27,27 @@ export function AddClaimableRewards({
 
           await Promise.all(
             protocolTokens.map(async (protocolToken) => {
-              const [reward] = await rewardAdapter.getPositions({
-                ...input,
-                protocolTokenAddresses: [protocolToken.address],
-              })
+              try {
+                const [reward] = await rewardAdapter.getPositions({
+                  ...input,
+                  protocolTokenAddresses: [protocolToken.address],
+                })
 
-              if (reward) {
-                if (reward.tokens) {
-                  protocolToken.tokens = [
-                    ...(protocolToken.tokens ?? []),
-                    ...reward.tokens,
-                  ]
+                if (reward) {
+                  if (reward.tokens) {
+                    protocolToken.tokens = [
+                      ...(protocolToken.tokens ?? []),
+                      ...reward.tokens,
+                    ]
+                  }
                 }
+              } catch (error) {
+                if (
+                  (error as Error).message === 'Protocol token pool not found'
+                ) {
+                  return
+                }
+                throw error
               }
             }),
           )

--- a/src/core/decorators/addClaimedRewards.ts
+++ b/src/core/decorators/addClaimedRewards.ts
@@ -25,9 +25,16 @@ export function AddClaimedRewards({
             rewardAdapterId,
           )
 
-          const claimedRewards = await rewardAdapter.getWithdrawals(input)
+          try {
+            const claimedRewards = await rewardAdapter.getWithdrawals(input)
 
-          movements.push(...claimedRewards)
+            movements.push(...claimedRewards)
+          } catch (error) {
+            if ((error as Error).message === 'Protocol token pool not found') {
+              return
+            }
+            throw error
+          }
         }),
       )
 

--- a/src/core/decorators/addClaimedRewards.ts
+++ b/src/core/decorators/addClaimedRewards.ts
@@ -30,7 +30,7 @@ export function AddClaimedRewards({
 
             movements.push(...claimedRewards)
           } catch (error) {
-            if ((error as Error).message === 'Protocol token pool not found') {
+            if (error instaceOf Error && error.message === 'Protocol token pool not found') {
               return
             }
             throw error

--- a/src/core/decorators/addClaimedRewards.ts
+++ b/src/core/decorators/addClaimedRewards.ts
@@ -25,16 +25,17 @@ export function AddClaimedRewards({
             rewardAdapterId,
           )
 
-          try {
-            const claimedRewards = await rewardAdapter.getWithdrawals(input)
+          const isSupported = (await rewardAdapter.getProtocolTokens()).find(
+            (token) => token.address == input.protocolTokenAddress,
+          )
 
-            movements.push(...claimedRewards)
-          } catch (error) {
-            if (error instaceOf Error && error.message === 'Protocol token pool not found') {
-              return
-            }
-            throw error
+          if (!isSupported) {
+            return
           }
+
+          const claimedRewards = await rewardAdapter.getWithdrawals(input)
+
+          movements.push(...claimedRewards)
         }),
       )
 

--- a/src/core/utils/aggregateFiatBalances.test.ts
+++ b/src/core/utils/aggregateFiatBalances.test.ts
@@ -13,7 +13,7 @@ const protocolToken = {
   symbol: 'jcoin',
   type: TokenType.Protocol,
   decimals,
-  priceRaw,
+  priceRaw: undefined,
   balanceRaw,
   tokenId: undefined,
 }
@@ -41,6 +41,7 @@ describe('aggregateFiatBalances', () => {
         tokens: [
           {
             ...underlyingToken,
+            priceRaw: undefined,
             tokens: [underlyingToken],
           },
         ],
@@ -61,32 +62,6 @@ describe('aggregateFiatBalances', () => {
     })
   })
 
-  it('throws error for non-fiat token at base', () => {
-    const testData = [
-      {
-        ...protocolToken,
-
-        tokens: [
-          {
-            ...underlyingToken,
-            tokens: [underlyingToken],
-          },
-        ],
-      },
-    ]
-
-    try {
-      aggregateFiatBalances(
-        testData as unknown as (Underlying | ProtocolPosition)[],
-      )
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (error: any) {
-      expect(error.message).toEqual(
-        'Unable to calculate profits, missing USD price for token position 0x',
-      )
-    }
-  })
-
   it('correctly aggregates balances for tokens with same identifier', () => {
     const testData = [
       {
@@ -94,10 +69,12 @@ describe('aggregateFiatBalances', () => {
         tokens: [
           {
             ...underlyingToken,
+            priceRaw: undefined,
             tokens: [underlyingToken],
           },
           {
             ...underlyingToken,
+            priceRaw: undefined,
             tokens: [underlyingToken],
           },
         ],

--- a/src/core/utils/aggregateFiatBalances.ts
+++ b/src/core/utils/aggregateFiatBalances.ts
@@ -1,5 +1,6 @@
 import { Underlying, ProtocolPosition, TokenType } from '../../types/adapter'
 import { Erc20Metadata } from '../../types/erc20Metadata'
+import { logger } from './logger'
 
 export function aggregateFiatBalances(
   topLevelTokens: (Underlying | ProtocolPosition)[],
@@ -8,6 +9,8 @@ export function aggregateFiatBalances(
   {
     protocolTokenMetadata: Erc20Metadata & { tokenId?: string }
     usdRaw: bigint
+    hasTokensWithoutUSDPrices?: boolean
+    tokensWithoutUSDPrices?: Underlying[]
   }
 > {
   const result: Record<
@@ -15,51 +18,61 @@ export function aggregateFiatBalances(
     {
       protocolTokenMetadata: Erc20Metadata & { tokenId?: string }
       usdRaw: bigint
+      hasTokensWithoutUSDPrices?: boolean
+      tokensWithoutUSDPrices?: Underlying[]
     }
   > = {}
 
   const processToken = (
     currentToken: Underlying | ProtocolPosition,
     topLevelTokenMetadata: Erc20Metadata & { tokenId?: string },
-  ): bigint => {
-    if (
-      (currentToken.type == TokenType.Underlying ||
-        currentToken.type == TokenType.UnderlyingClaimable) &&
-      currentToken.priceRaw
-    ) {
-      const key = topLevelTokenMetadata.tokenId ?? topLevelTokenMetadata.address
-      const currentBalance = currentToken.balanceRaw
-      const price = currentToken.priceRaw!
+  ): void => {
+    let price: bigint | undefined
 
-      result[key] = {
-        protocolTokenMetadata: {
-          address: topLevelTokenMetadata.address,
-          name: topLevelTokenMetadata.name,
-          symbol: topLevelTokenMetadata.symbol,
-          decimals: topLevelTokenMetadata.decimals,
-          tokenId: topLevelTokenMetadata.tokenId,
-        },
-        usdRaw:
-          (result[key]?.usdRaw || BigInt(0)) +
-          (currentBalance * price) / 10n ** BigInt(currentToken.decimals),
-      }
+    const key = topLevelTokenMetadata.tokenId ?? topLevelTokenMetadata.address
+    const currentBalance = currentToken.balanceRaw
 
-      return currentBalance
+    result[key] = {
+      protocolTokenMetadata: {
+        address: topLevelTokenMetadata.address,
+        name: topLevelTokenMetadata.name,
+        symbol: topLevelTokenMetadata.symbol,
+        decimals: topLevelTokenMetadata.decimals,
+        tokenId: topLevelTokenMetadata.tokenId,
+      },
+      usdRaw: result[key]?.usdRaw ?? 0n,
+    }
+
+    if ('priceRaw' in currentToken) {
+      price = currentToken.priceRaw ?? 0n
+
+      result[key]!.usdRaw =
+        (result[key]?.usdRaw ?? 0n) +
+        (currentBalance * price!) / 10n ** BigInt(currentToken.decimals)
     }
 
     // Recursively process nested tokens if they exist
     if (currentToken.tokens && currentToken.tokens.length > 0) {
-      return currentToken.tokens.reduce(
-        (acc, nestedToken) =>
-          acc + processToken(nestedToken, topLevelTokenMetadata),
-        BigInt(0),
+      currentToken.tokens.forEach((nestedToken) =>
+        processToken(nestedToken, topLevelTokenMetadata),
       )
     }
 
-    // Throw an error if a non-Fiat token is found at the base
-    throw new Error(
-      `Unable to calculate profits, missing USD price for token position ${currentToken.address}`,
-    )
+    // Log an error if a non-Fiat token is found at the base
+    if (
+      !price &&
+      price !== 0n &&
+      (!currentToken.tokens || currentToken.tokens.length == 0)
+    ) {
+      logger.warn(
+        `Unable to calculate profits, missing USD price for token position ${currentToken.address}`,
+      )
+
+      result[key]!.hasTokensWithoutUSDPrices = true
+      result[key]!.tokensWithoutUSDPrices = result[key]!.tokensWithoutUSDPrices
+        ? [...result[key]!.tokensWithoutUSDPrices!, currentToken as Underlying]
+        : [currentToken as Underlying]
+    }
   }
 
   topLevelTokens.forEach((token) => processToken(token, token))

--- a/src/core/utils/aggregateFiatBalances.ts
+++ b/src/core/utils/aggregateFiatBalances.ts
@@ -1,4 +1,4 @@
-import { Underlying, ProtocolPosition, TokenType } from '../../types/adapter'
+import { Underlying, ProtocolPosition } from '../../types/adapter'
 import { Erc20Metadata } from '../../types/erc20Metadata'
 import { logger } from './logger'
 

--- a/src/core/utils/aggregateFiatBalancesFromMovements.test.ts
+++ b/src/core/utils/aggregateFiatBalancesFromMovements.test.ts
@@ -1,7 +1,7 @@
 import { MovementsByBlock, TokenType } from '../../types/adapter'
 import { aggregateFiatBalancesFromMovements } from './aggregateFiatBalancesFromMovements'
 
-const balanceRaw = 2000000000000000000n
+const balanceRaw = 2n * 10n ** 18n
 const priceRaw = BigInt(Math.pow(2, 18))
 const decimals = 18
 
@@ -23,16 +23,7 @@ const protocolToken2 = {
 
   tokenId: undefined,
 }
-const underlyingTokenWithPrice = {
-  name: 'underlying',
-  symbol: 'underlying',
-  type: TokenType.Underlying,
-  address: '0x1',
-  decimals,
-  balanceRaw,
-  priceRaw,
-}
-const underlyingTokenWithoutPrice = {
+const underlyingToken = {
   name: 'underlying',
   symbol: 'underlying',
   type: TokenType.Underlying,
@@ -51,19 +42,19 @@ describe('aggregateFiatBalancesFromMovements', () => {
     const testData: MovementsByBlock[] = [
       {
         protocolToken: protocolToken1,
-        tokens: [underlyingTokenWithPrice, underlyingTokenWithPrice],
+        tokens: [underlyingToken, underlyingToken],
         blockNumber: 11,
         transactionHash: '0x',
       },
       {
         protocolToken: protocolToken2,
-        tokens: [underlyingTokenWithPrice, underlyingTokenWithPrice],
+        tokens: [underlyingToken, underlyingToken],
         blockNumber: 11,
         transactionHash: '0x',
       },
       {
         protocolToken: protocolToken2,
-        tokens: [underlyingTokenWithPrice],
+        tokens: [underlyingToken],
         blockNumber: 11,
         transactionHash: '0x',
       },
@@ -90,58 +81,27 @@ describe('aggregateFiatBalancesFromMovements', () => {
         protocolToken: protocolToken1,
         tokens: [
           {
-            ...underlyingTokenWithoutPrice,
-
-            tokens: [underlyingTokenWithPrice],
+            ...underlyingToken,
+            priceRaw: undefined,
+            tokens: [underlyingToken],
           },
-          underlyingTokenWithoutPrice,
         ],
       },
       {
         protocolToken: protocolToken1,
-        tokens: [underlyingTokenWithPrice, underlyingTokenWithPrice],
+        tokens: [underlyingToken, underlyingToken],
       },
     ]
 
-    expect(
-      aggregateFiatBalancesFromMovements(
-        testData as unknown as MovementsByBlock[],
-      ),
-    ).toEqual({
+    const result = aggregateFiatBalancesFromMovements(
+      testData as MovementsByBlock[],
+    )
+
+    expect(result).toEqual({
       [protocolToken1.address]: {
         protocolTokenMetadata: protocolToken1,
-        usdRaw: usdRaw * 4n,
+        usdRaw: usdRaw * 3n,
       },
     })
-  })
-
-  it('throws error for non-fiat token at base', async () => {
-    const testData = [
-      {
-        protocolToken: protocolToken1,
-        tokens: [
-          {
-            ...underlyingTokenWithoutPrice,
-            tokens: [underlyingTokenWithoutPrice],
-          },
-          underlyingTokenWithoutPrice,
-        ],
-      },
-      {
-        protocolToken: protocolToken1,
-        tokens: [underlyingTokenWithoutPrice, underlyingTokenWithoutPrice],
-      },
-    ]
-
-    try {
-      await aggregateFiatBalancesFromMovements(
-        testData as unknown as MovementsByBlock[],
-      )
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (error: any) {
-      expect(error.message).toEqual(
-        'Unable to calculate profits, missing USD price for token movement: non-fiat',
-      )
-    }
   })
 })

--- a/src/core/utils/buildIconUrl.ts
+++ b/src/core/utils/buildIconUrl.ts
@@ -1,8 +1,8 @@
 import { getAddress } from 'ethers'
 import { Chain, ChainName } from '../constants/chains'
+import { E_ADDRESS } from '../constants/E_ADDRESS'
 import { ZERO_ADDRESS } from '../constants/ZERO_ADDRESS'
 import { logger } from './logger'
-import { E_ADDRESS } from '../constants/E_ADDRESS'
 
 export function buildTrustAssetIconUrl(
   chainId: Chain,

--- a/src/defiProvider.ts
+++ b/src/defiProvider.ts
@@ -220,17 +220,15 @@ export class DefiProvider {
     const runner = async (adapter: IProtocolAdapter) => {
       const blockNumber = blockNumbers?.[adapter.chainId]
 
-      let protocolTokens = await adapter.getProtocolTokens()
-
-      if (filterProtocolToken) {
-        const filteredProtocolTokens = protocolTokens.filter(
-          (protocolToken) =>
-            protocolToken.address === getAddress(filterProtocolToken),
-        )
-        if (filteredProtocolTokens.length === 0) {
-          return { tokens: [] }
-        }
-        protocolTokens = filteredProtocolTokens
+      let protocolTokens = []
+      if (!filterProtocolToken) {
+        protocolTokens = await adapter.getProtocolTokens()
+      } else {
+        protocolTokens = [
+          {
+            address: filterProtocolToken,
+          },
+        ]
       }
 
       const tokens = await Promise.all(

--- a/src/responseAdapters.ts
+++ b/src/responseAdapters.ts
@@ -94,13 +94,15 @@ export function enrichMovements(
           ...accumulator,
           {
             ...token,
-            price: token.priceRaw
-              ? +formatUnits(
-                  token.priceRaw,
-                  priceAdapterConfig[chainId as keyof typeof priceAdapterConfig]
-                    .decimals,
-                )
-              : undefined,
+            price:
+              token.priceRaw || token.priceRaw === 0n
+                ? +formatUnits(
+                    token.priceRaw,
+                    priceAdapterConfig[
+                      chainId as keyof typeof priceAdapterConfig
+                    ].decimals,
+                  )
+                : undefined,
             priceRaw: undefined,
             balance: +formatUnits(token.balanceRaw, token.decimals),
             ...(token.tokens

--- a/src/scripts/featureCommands.ts
+++ b/src/scripts/featureCommands.ts
@@ -97,8 +97,6 @@ function addressCommand(
     )
     .showHelpAfterError()
     .action(async (userAddress, { protocols, chains, raw }) => {
-      console.log({ protocols, chains, raw })
-
       const filterProtocolIds = multiProtocolFilter(protocols)
       const filterChainIds = multiChainFilter(chains)
 
@@ -132,7 +130,6 @@ function transactionParamsCommand(
     )
     .showHelpAfterError()
     .action(async (action, protocolId, productId, chainId, inputs) => {
-      console.log({ action, protocolId, productId, chainId, inputs })
       const txInputParams = inputs.split(',')
 
       const protocol = protocolFilter(protocolId)

--- a/src/scripts/templates/simplePoolAdapter.ts
+++ b/src/scripts/templates/simplePoolAdapter.ts
@@ -156,7 +156,15 @@ export function simplePoolAdapterTemplate(
       const poolMetadata = (await this.buildMetadata())[protocolTokenAddress]
   
       if (!poolMetadata) {
-        logger.error({ protocolTokenAddress }, 'Protocol token pool not found')
+              logger.error(
+        {
+          protocolTokenAddress,
+          protocol: this.protocolId,
+          chainId: this.chainId,
+          product: this.productId,
+        },
+        'Protocol token pool not found',
+      )
         throw new Error('Protocol token pool not found')
       }
   

--- a/src/types/adapter.ts
+++ b/src/types/adapter.ts
@@ -321,6 +321,8 @@ export interface CalculationData {
   deposits: number
   startPositionValue: number
   endPositionValue: number
+  hasTokensWithoutUSDPrices?: boolean
+  tokensWithoutUSDPrices?: Underlying[]
 }
 
 export interface ProtocolAdapterParams {

--- a/src/types/testCase.ts
+++ b/src/types/testCase.ts
@@ -12,7 +12,11 @@ export type TestCase = {
     }
   | {
       method: 'profits'
-      input: { userAddress: string; timePeriod?: TimePeriod }
+      input: {
+        userAddress: string
+        timePeriod?: TimePeriod
+        includeRawValues?: boolean
+      }
       blockNumber?: number
     }
   | {

--- a/src/types/testCase.ts
+++ b/src/types/testCase.ts
@@ -16,6 +16,7 @@ export type TestCase = {
         userAddress: string
         timePeriod?: TimePeriod
         includeRawValues?: boolean
+        filterProtocolTokens?: string[]
       }
       blockNumber?: number
     }


### PR DESCRIPTION
- change to the way we handle missing prices on profits.
- Before we threw when one price was missing.
- Now we return positions and indicate if there is a price missing in the response.
- Also, handle when price is 0, before was returned as undefined instead of 0
- Also, bug fix which was stopping positions with reward tokens from returning.