### PR TITLE
feat: get lp token price

### DIFF
--- a/src/types/adapter.ts
+++ b/src/types/adapter.ts
@@ -253,6 +253,7 @@ export interface ProtocolTokenUnderlyingRate extends Erc20Metadata {
    * Always equal to 1
    * We are finding the underlying value of 1 LP token
    */
+  tokenId?: string
   baseRate: 1
   type: typeof TokenType.Protocol
   tokens?: UnderlyingTokenRate[]


### PR DESCRIPTION
- tinkering to see can we implement lpTokenPrice on the uniswap V3 adapter
- its basically possible now that we have tokenId

BUT:

Im not sure if I should return the claimable fees along with the current price of the nft position if we do I need to update the type on ProtocolTokenUnderlyingRate to alow if to retrun token type underlying as well as token type Claimable fess