### PR TITLE
force node version to 20

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,9 @@
         "typedoc-plugin-markdown": "^3.16.0",
         "typedoc-plugin-mdn-links": "^3.1.0",
         "typescript": "^5.1.6"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "type": "git",
     "url": "git+https://github.com/consensys-vertical-apps/mmi-defi-adapters"
   },
+  "engines": {
+    "node": ">=20.0.0"
+  },
   "main": "lib/main/index.js",
   "types": "lib/main/index.d.ts",
   "files": [


### PR DESCRIPTION
![Screenshot from 2024-03-18 09-48-34](https://github.com/consensys-vertical-apps/mmi-defi-adapters/assets/1970725/91572b77-7e4a-4432-b0f2-2291cbbe51da)
