### PR TITLE
check metadata and protocol tokens for invalid addresses

### DIFF
--- a/packages/adapters-library/src/scripts/addressValidation.ts
+++ b/packages/adapters-library/src/scripts/addressValidation.ts
@@ -1,0 +1,32 @@
+import { getAddress, isAddress } from 'ethers'
+import { Json } from '../types/json'
+
+export function getMetadataInvalidAddresses(metadata: Json): string[] {
+  if (typeof metadata === 'string') {
+    return isChecksummedOrNonEthAddress(metadata) ? [] : [metadata]
+  }
+
+  if (Array.isArray(metadata)) {
+    return metadata.flatMap((value) => getMetadataInvalidAddresses(value) || [])
+  }
+
+  if (metadata && typeof metadata === 'object') {
+    return Object.entries(metadata).flatMap(([key, value]) => {
+      const keyInvalidAddresses = getMetadataInvalidAddresses(key)
+      const valueInvalidAddresses = getMetadataInvalidAddresses(value)
+
+      return [...keyInvalidAddresses, ...valueInvalidAddresses]
+    })
+  }
+
+  return []
+}
+
+export function isChecksummedOrNonEthAddress(address: string): boolean {
+  // isAddress and getAddress throw when the address has a mixture of upper and lower case characters
+  // This function should not throw in that event, that's why a regex is used instead
+  return (
+    !address.match(/^0x[a-fA-F0-9]{40}$/) ||
+    (isAddress(address) && getAddress(address) === address)
+  )
+}

--- a/packages/adapters-library/src/scripts/buildMetadata.ts
+++ b/packages/adapters-library/src/scripts/buildMetadata.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from 'node:fs'
 import path from 'node:path'
+import chalk from 'chalk'
 import { Command } from 'commander'
 import partition from 'lodash/partition'
 import { parse, print, types, visit } from 'recast'
@@ -14,6 +15,7 @@ import { pascalCase } from '../core/utils/caseConversion'
 import { logger } from '../core/utils/logger'
 import { writeAndLintFile } from '../core/utils/writeAndLintFile'
 import { Json } from '../types/json'
+import { getMetadataInvalidAddresses } from './addressValidation'
 import { multiChainFilter, multiProtocolFilter } from './commandFilters'
 import { sortEntries } from './utils/sortEntries'
 import n = types.namedTypes
@@ -78,6 +80,23 @@ export function buildMetadata(
                 chainId: Chain
                 fileKey: string
               }
+            }
+
+            const invalidAddresses = getMetadataInvalidAddresses(metadata)
+
+            if (invalidAddresses.length > 0) {
+              console.error(
+                chalk.red(
+                  'The following addresses found in the metadata file are not in checksum format.',
+                ),
+              )
+              console.error(chalk.yellow(invalidAddresses.join('\n')))
+              console.error(
+                chalk.green(
+                  '\nPlease ensure that addresses are in checksum format by wrapping them with getAddress from the ethers package.',
+                ),
+              )
+              return
             }
 
             await writeMetadataToFile({


### PR DESCRIPTION
## **Description**

<!--
Write a short description of the changes included in this pull request. Include relevant links to the protocol docs
-->

## **Pre-merge author checklist**

- [ ] A brief description of the protocol and adapters is added to the PR
- [ ] Files outside the protocol folder are not being edited and, if they are, it's clearly explained why in the PR
- [ ] `update me` comments are removed
- [ ] Contracts used are verified for that chain block explorer
- [ ] Test cases with a block number have been added to the `testCases.ts` file for every relevant method that has been implemented
  - [ ] positions
  - [ ] prices
  - [ ] deposits
  - [ ] withdrawals
  - [ ] profits
  - [ ] tvl
  - [ ] apr
  - [ ] apy
- [ ] `getAddress` from `ethers`
  - [ ] Is used to parse hardcoded addresses
  - [ ] Is used to parse addresses that come from contract calls when it is not clear they'll be in checksum format
  - [ ] It is NOT used to parse addresses from input methods
  - [ ] It is NOT used to parse addresses from metadata
- [ ] For every adapter that extends `SimplePoolAdapter`
  - [ ] `getPositions` is not overwritten and, if it is, it's clearly explained why in the PR
  - [ ] `unwrap` is not overwritten and, if it is, it's clearly explained why in the PR
- [ ] If the adapters requires to fetch static data on-chain (e.g. pool ids, token metadata, etc)
  - [ ] The adapter implements `IMetadataBuilder`
  - [ ] The `buildMetadata` method is implemented with the `@CacheToFile` decorator
  - [ ] All the static data is stored within the metadata JSON file
