### PR TITLE
MMI-5152-update-the-de-fi-readme-with-guided-steps

### DIFF
--- a/packages/adapters-library/README.md
+++ b/packages/adapters-library/README.md
@@ -20,6 +20,9 @@ Watch the [setup video](https://drive.google.com/file/d/1bp9Y8uxQDYxgIyMTk5945vL
    - `npm i` to install dependencies 
 2. Run project:
    - `npm run dev` to run the project
+
+Continue watching videos for the following steps or, alternatively, find a written version in [Steps to create a read adapter](./readme-new-adapter.md)
+
 ### Build adapter steps
 
 Watch the [build adapter video](https://drive.google.com/file/d/1Pl0yB2d1s-3oKFCXAyRhKx7rK2x43Qtf/view  "Watch the build adapter steps") for a detailed guide.

--- a/packages/adapters-library/readme-new-adapter.md
+++ b/packages/adapters-library/readme-new-adapter.md
@@ -1,0 +1,157 @@
+# Steps to build a new adapter
+
+This a detailed step by step guide on how to create a new adapter.
+
+## 1. Run the adapter CLI command
+The following command will start the new adapter CLI.
+```
+npm run new-adapter
+```
+
+## 2. Follow CLI guidelines to create new adapter
+
+### Q1 Protocol key
+Enter a name for your protocol in PascalCase, a convention in which the first letter of each word in a compound word is capitalized without spaces or punctuation, e.g., LenderV2, MyProtocolFinance.
+
+### Q2 Protocol id
+Enter a name for your protocol in kebab-case, a convention where all letters are lowercase and words are separated by hyphens, e.g., lender-v2, my-protocol-finance.
+
+A value will be suggested based on the first answer, but at this point it can be edited.
+
+### Q3 Adapter class name
+This question is skipped as we have changed the convention to base it on other answers.
+
+### Q4 Chains
+Select every chain in which this product is deployed:
+Ethereum, Optimism, Bsc, Polygon, Fantom, Base, Arbitrum, Avalanche, Linea.
+
+### Q5 Product id
+Enter a name for your product in kebab-case, e.g., pool, supply, borrow.
+
+### Q6 Building path
+Select how you would like to create the adapter. You can either:
+- Create it from scratch using the smart adapter builder, which will require additional questions to be answered.
+- Create a fork of one of our supported protocols, e.g., UniswapV2, CompoundV2.
+- (Coming soon) Copy an existing adapter
+
+### Q7 Defi asset structure
+Select one of the following options
+  1. Single ERC20 protocol token (Like stETH)
+  2. Multiple ERC20 protocol tokens (Like Aave: aETH, aUSDC, Compound: cETH, cUSDC)
+  3. Non fungible token (Like Uniswap V3)
+  4. Contract position (Like Morpho)
+  5. Other
+
+### Q8 ERC20 standard events
+Select if the protocol token contracts are just regular ERC20 tokens with mint, burn and transfer events.
+
+### Q9 balanceOf
+Select if the protocol token contracts has a `balanceOf(address)` method.
+
+### Q10 Number of underlying
+Select if protocol tokens have one (stEth, aEth) or multiple underlying tokens (Curve.fi DAI/USDC/USDT).
+
+### Q11/12 Quantity of underlyings for each protocol token
+Select whether one of your protocol tokens maps to a single underlying token, or it can be derived from the total supply, or additional calculations are necessary.
+
+
+### Q13 Additional rewards
+Select whether the product offer additional rewards beyond the primary earnings.
+
+### Q14 Reward details
+Select type of rewards offered by the protocol
+  1. Rewards are linked to defi asset (like curve and convex)
+  2. Extra rewards are linked to defi asset (like curve permissionsless rewards
+  3. Protocol rewards like compound's protocol rewards
+
+## 3. Inspect adapter code and complete missing methods
+A set of files would have been generated, one of them being the adapter itself.
+
+### 3.1 Contract factories and types
+The next steps involve adding implementation details to the adapter. For that, it might be necessary to add new contract ABIs to create factories that allow a type safe approach to interacting with those contracts. In order to do so, drop a json file with the abi for each contract in the `contracts/abis` folder of your protocol (e.g. `src/adapters/your-protocol-id/contracts/abis`).
+
+After that, run the following command to generate contract factories that can be imported afterwards.
+```
+npm run build-types
+```
+
+### 3.2 Filling implementation gaps for the adapter
+Upon inspecting the adapter start by filling details for the following methods
+- `getProtocolDetails`
+- `buildMetadata`
+
+After implementing `buildMetadata`, create the json metadata files that will be used at runtime by running
+
+```
+npm run build-metadata -- -p your-protocol-id
+```
+
+Then check if the following methods need to be implemented or code has already been added based on the CLI questions
+- `getProtocolTokens`
+- `getPositions`
+- `unwrap`
+- `getWithdrawals`
+- `getDeposits`
+- `getTotalValueLocked`
+
+Finally, if any reward method has been added, the implementation will have to be provided for it to work:
+- `getRewardPositions`
+- `getRewardWithdrawals`
+- `getExtraRewardPositions`
+- `getExtraRewardWithdrawals`
+
+## 4 Create snapshot tests
+The last step involves creating tests to validate the adapter results nd ensure tht future changes don't break it.
+
+Inside the protocol folder there should be a folder called `tests` and a file called `testCases.ts` (e.g. src/adapters/your-protocol-id/tests/testCases.ts`). This file exports an array of test cases.
+
+You need to specify the `chain` and `method` for all test cases. Optionally, you can specify a `key` to identify the file, but this is only required if you write more than one test for the same `method` and `chain`.
+
+### 4.1 Positions
+To get a snapshot of the positions you need to set `method: 'positions'` and provide an `input` field with the `userAddress`. Optionally, you can specify a `blockNumber`, but this is not required and the latest will be used and recorded if it's left empty. This will run for all the products of this protocol
+
+Example:
+```
+{
+    chainId: Chain.Ethereum,
+    method: 'positions',
+    input: {
+      userAddress: '0x161D61e30284A33Ab1ed227beDcac6014877B3DE',
+    },
+  }
+```
+
+### 4.2 Profits
+To get a snapshot of the profits you need to set `method: 'profits'` and provide an `input` field with the `userAddress` and, optionally, `timePeriod`, which will default to one day if left empty. Optionally, you can specify a `blockNumber`, but this is not required and the latest will be used and recorded if it's left empty. This will run for all the products of this protocol.
+
+Example:
+```
+{
+    chainId: Chain.Ethereum,
+    method: 'profits',
+    input: {
+      userAddress: '0x161D61e30284A33Ab1ed227beDcac6014877B3DE',
+    },
+  }
+```
+
+### 4.3 Deposits/Withdrawals/Repays/Borrows
+To get a snapshot of any of these methods, set `method: 'deposits' | 'withdrawals' | 'repays' | 'borrows'`. The input field of these methods requires additional parameters to work. Including `userAddress', 'fromBlock', 'toBlock', 'protocolTokenAddress' and 'productId'.
+
+Example:
+```
+{
+    chainId: Chain.Ethereum,
+    method: 'deposits',
+    input: {
+      fromBlock: 198188138,
+      toBlock: 200597430,
+      userAddress: '0xbc0a54c02a1e80c8e25e8173a8a80baf116205b5',
+      protocolTokenAddress: '0x3bAa857646e5A0B475E75a1dbD38E7f0a6742058',
+      productId: 'supply',
+    },
+  },
+```
+
+### 4.4 TVL
+To get a snapshot of the TVL implementation, set `method: 'tvl'` and specify the protocol tokens with `filterProtocolToken: ['protocol-token-address1', 'protocol-token-address2']`. Optionally, you can specify a `blockNumber`, but this is not required and the latest will be used and recorded if it's left empty. This will run for all the products of this protocol.


### PR DESCRIPTION
## **Description**

<!--
Write a short description of the changes included in this pull request. Include relevant links to the protocol docs
-->

## **Pre-merge author checklist**

- [ ] A brief description of the protocol and adapters is added to the PR
- [ ] Files outside the protocol folder are not being edited and, if they are, it's clearly explained why in the PR
- [ ] `update me` comments are removed
- [ ] Contracts used are verified for that chain block explorer
- [ ] Test cases with a block number have been added to the `testCases.ts` file for every relevant method that has been implemented
  - [ ] positions
  - [ ] prices
  - [ ] deposits
  - [ ] withdrawals
  - [ ] profits
  - [ ] tvl
  - [ ] apr
  - [ ] apy
- [ ] `getAddress` from `ethers`
  - [ ] Is used to parse hardcoded addresses
  - [ ] Is used to parse addresses that come from contract calls when it is not clear they'll be in checksum format
  - [ ] It is NOT used to parse addresses from input methods
  - [ ] It is NOT used to parse addresses from metadata
- [ ] For every adapter that extends `SimplePoolAdapter`
  - [ ] `getPositions` is not overwritten and, if it is, it's clearly explained why in the PR
  - [ ] `unwrap` is not overwritten and, if it is, it's clearly explained why in the PR
- [ ] If the adapters requires to fetch static data on-chain (e.g. pool ids, token metadata, etc)
  - [ ] The adapter implements `IMetadataBuilder`
  - [ ] The `buildMetadata` method is implemented with the `@CacheToFile` decorator
  - [ ] All the static data is stored within the metadata JSON file
