### PR TITLE
Error-filter

### DIFF
--- a/packages/adapters-library/src/core/adapters/UniswapV2PoolForkAdapter.ts
+++ b/packages/adapters-library/src/core/adapters/UniswapV2PoolForkAdapter.ts
@@ -27,7 +27,10 @@ import { Erc20Metadata } from '../../types/erc20Metadata'
 import { AdaptersController } from '../adaptersController'
 import { Chain } from '../constants/chains'
 import { IMetadataBuilder } from '../decorators/cacheToFile'
-import { NotImplementedError } from '../errors/errors'
+import {
+  NotImplementedError,
+  ProtocolTokenFilterRequiredError,
+} from '../errors/errors'
 import { CustomJsonRpcProvider } from '../provider/CustomJsonRpcProvider'
 import { filterMapAsync } from '../utils/filters'
 import { getTokenMetadata } from '../utils/getTokenMetadata'
@@ -194,9 +197,7 @@ export abstract class UniswapV2PoolForkAdapter implements IProtocolAdapter {
       input.protocolTokenAddresses &&
       input.protocolTokenAddresses.length === 0
     ) {
-      throw new Error(
-        'No protocol token address filter provided, must be provided for this adapter due to the large number of pools',
-      )
+      throw new ProtocolTokenFilterRequiredError()
     }
 
     if (this.metadataBased) {
@@ -634,13 +635,7 @@ export abstract class UniswapV2PoolForkAdapter implements IProtocolAdapter {
       factoryAddress,
       this.provider,
     )
-    const allPairsLength = 1 ?? Number(await factoryContract.allPairsLength())
-
-    if (allPairsLength > this.MAX_FACTORY_POOL_COUNT) {
-      throw new Error(
-        `Factory job size exceeds the limit ${allPairsLength} > ${this.MAX_FACTORY_POOL_COUNT}`,
-      )
-    }
+    const allPairsLength = Number(await factoryContract.allPairsLength())
 
     // Define jobSize to limit how many pairs to process in one go
     const jobSize = Math.min(this.MAX_FACTORY_POOL_COUNT, allPairsLength)

--- a/packages/adapters-library/src/core/errors/errors.ts
+++ b/packages/adapters-library/src/core/errors/errors.ts
@@ -143,3 +143,11 @@ export class MulticallError extends BaseError {
     this.maxBatchSize = maxBatchSize
   }
 }
+
+export class ProtocolTokenFilterRequiredError extends BaseError {
+  constructor(
+    message = 'Too many tokens to fetch, protocolTokenAddresses filter must be provided',
+  ) {
+    super(message)
+  }
+}

--- a/packages/adapters-library/src/scripts/helpers.ts
+++ b/packages/adapters-library/src/scripts/helpers.ts
@@ -4,7 +4,10 @@ import { Erc20__factory } from '../contracts'
 import { TransferEvent } from '../contracts/Erc20'
 import { ZERO_ADDRESS } from '../core/constants/ZERO_ADDRESS'
 import { Chain } from '../core/constants/chains'
-import { MaxMovementLimitExceededError } from '../core/errors/errors'
+import {
+  MaxMovementLimitExceededError,
+  ProtocolTokenFilterRequiredError,
+} from '../core/errors/errors'
 import { CustomJsonRpcProvider } from '../core/provider/CustomJsonRpcProvider'
 import { filterMapAsync } from '../core/utils/filters'
 import { getOnChainTokenMetadata } from '../core/utils/getTokenMetadata'
@@ -62,9 +65,7 @@ export class Helpers {
   }): Promise<ProtocolPosition[]> {
     // Otherwise we might overload the node
     if (!protocolTokenAddresses && protocolTokens.length > 1000) {
-      throw new Error(
-        'Too many tokens to fetch, protocolTokenAddresses must be provided',
-      )
+      throw new ProtocolTokenFilterRequiredError()
     }
 
     return filterMapAsync(protocolTokens, async (protocolToken) => {

--- a/packages/adapters-library/src/tests/detect-errors.test.ts
+++ b/packages/adapters-library/src/tests/detect-errors.test.ts
@@ -47,6 +47,7 @@ function filterErrors(
         'NotApplicableError',
         'NotImplementedError',
         'NotSupportedError',
+        'ProtocolTokenFilterRequiredError',
       ].includes(responseEntry.error.details?.name),
   )
 }


### PR DESCRIPTION
## **Description**

<!--
Write a short description of the changes included in this pull request. Include relevant links to the protocol docs
-->

## **Pre-merge author checklist**

- [ ] A brief description of the protocol and adapters is added to the PR
- [ ] Files outside the protocol folder are not being edited and, if they are, it's clearly explained why in the PR
- [ ] `update me` comments are removed
- [ ] Contracts used are verified for that chain block explorer
- [ ] Test cases with a block number have been added to the `testCases.ts` file for every relevant method that has been implemented
  - [ ] positions
  - [ ] profits
  - [ ] prices (unwrap)
  - [ ] deposits
  - [ ] withdrawals
  - [ ] repays
  - [ ] borrows
  - [ ] tvl
- [ ] `getAddress` from `ethers`
  - [ ] Is used to parse hardcoded addresses
  - [ ] Is used to parse addresses that come from contract calls when it is not clear they'll be in checksum format
  - [ ] It is NOT used to parse addresses from input methods
  - [ ] It is NOT used to parse addresses from metadata
- [ ] For every adapter that extends `SimplePoolAdapter`
  - [ ] `getPositions` is not overwritten and, if it is, it's clearly explained why in the PR
  - [ ] `unwrap` is not overwritten and, if it is, it's clearly explained why in the PR
- [ ] If the adapters requires to fetch static data on-chain (e.g. pool ids, token metadata, etc)
  - [ ] The adapter implements `IMetadataBuilder`
  - [ ] The `buildMetadata` method is implemented with the `@CacheToFile` decorator
  - [ ] All the static data is stored within the metadata JSON file
