### PR TITLE
feat: plug apy calculation to profits

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,8 @@ Follow the steps below to contribute changes:
    ```
 6. Test your new adapter by running the scripts detailed in the README, e.g.,
    ```bash
-   npm run positions ${userAddress}
+   npm run positions <user address> -- -p <protocol id>
+   npm run profits <user address> -- -p <protocol id>
    npm run prices
    ```
    and so on.

--- a/packages/adapters-library/src/core/apy-calculators/ApyCalculator.ts
+++ b/packages/adapters-library/src/core/apy-calculators/ApyCalculator.ts
@@ -5,7 +5,7 @@ import { Chain } from '../constants/chains'
  * Data structure than contains the calculated APY,
  * and attaches various useful contextual information.
  */
-export interface ApyCalculation {
+export interface ApyInfo {
   apyPercent: number
   apy: number
   aprPercent: number
@@ -23,17 +23,40 @@ export interface ApyCalculation {
   protocolTokenAddress: string
 }
 
-export interface ApyCalculator<TArgs> {
+/**
+ * Whenever the APY calculation couldn't suceed.
+ * For instance when no appropriate adapter was found,
+ * or runtime error.
+ */
+export interface VoidApyInfo {
+  apyPercent: null
+  apy: null
+  aprPercent: null
+  apr: null
+  period: {
+    blocknumberStart: number
+    blocknumberEnd: number
+    interestPercent: null
+    interest: null
+  }
+  compounding: {
+    durationDays: null
+    frequency: null
+  }
+  protocolTokenAddress: string
+}
+
+export interface ApyCalculator {
   /**
    * Calculates the APY for a given user and protocol.
    *
-   * @param {TArgs} args - The arguments specific to the APY calculation.
-   * @returns {Promise<ApyCalculation>} A promise that resolves to an object representing the APY calculation.
+   * @param {GetApyArgs} args - The arguments specific to the APY calculation.
+   * @returns {Promise<ApyInfo>} A promise that resolves to an object representing the APY calculation.
    */
-  getApy(args: TArgs): Promise<ApyCalculation>
+  getApy(args: GetApyArgs): Promise<ApyInfo | VoidApyInfo>
 }
 
-export type EvmApyArgs = {
+export type GetApyArgs = {
   positionStart: ProtocolPosition
   positionEnd: ProtocolPosition
   blocknumberStart: number

--- a/packages/adapters-library/src/core/apy-calculators/BalanceOfApyCalculator.test.ts
+++ b/packages/adapters-library/src/core/apy-calculators/BalanceOfApyCalculator.test.ts
@@ -18,7 +18,7 @@ describe('BalanceOfApyCalculator', () => {
   const testCases = [
     {
       description:
-        'Test Case 1 - Aave V2 - aEthWETH - Over 1 day - on 2024-10-13',
+        'Test Case 1 - aave-v3 - aEthWETH - Over 1 day - on 2024-10-13',
       userAddress: '0x1A0459cade0A33B9B054ba6F3942156Ea183c41F', // For information only. Isn't used by the tested code
       protocolTokenAddress: '0x4d5F47FA6A74757f35C14fD3a6Ef8E3C9BC514E8',
       blocknumberStart: 20735336,
@@ -55,7 +55,7 @@ describe('BalanceOfApyCalculator', () => {
     },
     {
       description:
-        'Test Case 2 - Lido - stETH -  Over 7 days - From 2024-07-20 to 2024-07-27',
+        'Test Case 2 - lido - stETH -  Over 7 days - From 2024-07-20 to 2024-07-27',
       userAddress: '0xEB9c1CE881F0bDB25EAc4D74FccbAcF4Dd81020a', // For information only. Isn't used by the tested code
       protocolTokenAddress: '0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84',
       blocknumberStart: 20295271,
@@ -92,7 +92,7 @@ describe('BalanceOfApyCalculator', () => {
     },
     {
       description:
-        'Test Case 3 - Maker DAO - sDai - Over 1 Month - From 2024-09-03 to  2024-10-03',
+        'Test Case 3 - maker - sDai - Over 1 Month - From 2024-09-03 to  2024-10-03',
       userAddress: '0xdd8AA75dF331158BEAD8C17d05dD26F96EE08Dc7', // For information only. Isn't used by the tested code
       protocolTokenAddress: '0x83F20F44975D03b1b09e64809B757c47f942BEeA',
       blocknumberStart: 20667923,

--- a/packages/adapters-library/src/core/apy-calculators/VoidApyCalculator.ts
+++ b/packages/adapters-library/src/core/apy-calculators/VoidApyCalculator.ts
@@ -1,0 +1,30 @@
+import { ApyCalculator, GetApyArgs, VoidApyInfo } from './ApyCalculator'
+
+/**
+ * Default APY calculator that no-ops.
+ */
+export class VoidApyCalculator implements ApyCalculator {
+  public async getApy({
+    blocknumberStart,
+    blocknumberEnd,
+    protocolTokenAddress,
+  }: GetApyArgs): Promise<VoidApyInfo> {
+    return Promise.resolve({
+      apyPercent: null,
+      apy: null,
+      aprPercent: null,
+      apr: null,
+      period: {
+        blocknumberStart,
+        blocknumberEnd,
+        interestPercent: null,
+        interest: null,
+      },
+      compounding: {
+        durationDays: null,
+        frequency: null,
+      },
+      protocolTokenAddress,
+    })
+  }
+}

--- a/packages/adapters-library/src/core/apy-calculators/helpers.test.ts
+++ b/packages/adapters-library/src/core/apy-calculators/helpers.test.ts
@@ -1,4 +1,4 @@
-import { computeApr, computeApy } from './common'
+import { computeApr, computeApy } from './helpers'
 
 describe('computeApr', () => {
   it('computes correctly', () => {

--- a/packages/adapters-library/src/core/apy-calculators/helpers.ts
+++ b/packages/adapters-library/src/core/apy-calculators/helpers.ts
@@ -1,3 +1,9 @@
+import { IProtocolAdapter } from '../../types/IProtocolAdapter'
+import { InvalidArgumentError } from '../errors/errors'
+import { ApyCalculator } from './ApyCalculator'
+import { BalanceOfApyCalculator } from './BalanceOfApyCalculator'
+import { VoidApyCalculator } from './VoidApyCalculator'
+
 /**
  * Computes the Annual Percentage Rate (APR) given the interest earned and the frequency of compounding periods.
  *
@@ -29,8 +35,33 @@ export const computeApr = (interest: number, frequency: number) =>
  */
 export const computeApy = (apr: number, frequency: number) => {
   if (frequency === 0)
-    throw new Error(
+    throw new InvalidArgumentError(
       'Frequency cannot be 0 as it would result in division by zero.',
     )
   return Math.pow(1 + apr / frequency, frequency) - 1
+}
+
+/**
+ * Creates an appropriate APY calculator for a given protocol adapter.
+ *
+ * @param {IProtocolAdapter} adapter - The protocol adapter for which to create an APY calculator.
+ * @returns {ApyCalculator} - An instance of `ApyCalculator`
+ */
+export const createApyCalculatorFor = async (
+  adapter: IProtocolAdapter,
+): Promise<ApyCalculator> => {
+  try {
+    const protocolTokens = await adapter.getProtocolTokens()
+
+    if (protocolTokens[0]?.underlyingTokens.length === 1)
+      return new BalanceOfApyCalculator()
+
+    return new VoidApyCalculator()
+  } catch (error) {
+    console.warn(
+      'Error encountered while creating an APY calculator. Defaulting to VoidApyCalculator.',
+      error,
+    )
+    return new VoidApyCalculator()
+  }
 }

--- a/packages/adapters-library/src/core/errors/errors.ts
+++ b/packages/adapters-library/src/core/errors/errors.ts
@@ -151,3 +151,9 @@ export class ProtocolTokenFilterRequiredError extends BaseError {
     super(message)
   }
 }
+
+export class InvalidArgumentError extends BaseError {
+  constructor(message = 'Invalid argument') {
+    super(message)
+  }
+}


### PR DESCRIPTION
Plugs the basic APY calculator to the profits data. It's used for any protocol with a **single** underlying token.

For others, default to no-op for now.

Here's a sample of data returned by
`npm run profits 0x1A0459cade0A33B9B054ba6F3942156Ea183c41F -- -p aave-v3`

```json
 {
        "address": "0x5Ee5bf7ae06D1Be5997A1A72006FE6C607eC6DE8",
        "name": "Aave Ethereum WBTC",
        "symbol": "aEthWBTC",
        "decimals": 8,
        "type": "protocol",
        "profit": 8791.227512120444,
        "performance": 0.025905679158860325,
        "apyInfo": {
          "apyPercent": 0.05261793309832008,
          "apy": 0.0005261793309832008,
          "aprPercent": 0.05260436006539615,
          "apr": 0.0005260436006539615,
          "period": {
            "blocknumberStart": 20914358,
            "blocknumberEnd": 20964380,
            "interestPercent": 0.0010088507409801999,
            "interest": 0.000010088507409802
          },
          "compounding": {
            "durationDays": 7,
            "frequency": 52.142857142857146
          },
          "protocolTokenAddress": "0x5Ee5bf7ae06D1Be5997A1A72006FE6C607eC6DE8"
        },
        "calculationData": {
          "withdrawals": 0,
          "deposits": 0,
          "repays": 0,
          "borrows": 0,
          "startPositionValue": 339355.22239005443,
          "endPositionValue": 348146.4499021749
        }
      }
```

Result is reasonably close to 
- What [Aave shows](https://app.aave.com/):
![image](https://github.com/user-attachments/assets/f9d8d119-d23f-4375-9b69-7c3f3797d23b)

- What [DefiLlama shows](https://defillama.com/yields/pool/7e382157-b1bc-406d-b17b-facba43b716e):
![image](https://github.com/user-attachments/assets/5e063a08-47f6-45fa-9f3c-6a3bb0e05530)

