### PR TITLE
feat: uniswap v3 fix

### DIFF
--- a/packages/adapters-cli/src/commands/library-commands.ts
+++ b/packages/adapters-cli/src/commands/library-commands.ts
@@ -65,15 +65,13 @@ export function libraryCommands(program: Command) {
         if (!filterUsingLocalIndex && !filterProtocolTokens) {
           console.log(`No DeFi positions cache detected. Max ${DEFAULT_MAX_POOLS_PER_ADAPTER_TO_CHECK} pools per adapter per chain only.
             
-To set up local cache:
-1. Run: docker-compose up --build
-2. Set environment variables in .env:
-   - DEFI_ADAPTERS_USE_POSITIONS_CACHE=true
-   - CACHE_DATABASE_URL=postgresql://postgres:postgres@0.0.0.0:5432/defi-adapters
-   - CACHE_DATABASE_DISABLE_SSL=true
-   - LOCAL_ENABLE_THIS_CHAIN_ONLY=ethereum (to limit scope to specific chains)
-   
-Warning: This will start indexing all DeFi positions for all chains unless scope is limited.`)
+              To set up local cache:
+              1. Run: docker-compose up --build
+              2. Set environment variables in .env:
+                - DEFI_ADAPTERS_USE_POSITIONS_CACHE=true
+                - CACHE_DATABASE_URL=postgresql://postgres:postgres@0.0.0.0:5432/defi-adapters
+                - CACHE_DATABASE_DISABLE_SSL=true
+                - LOCAL_ENABLE_THIS_CHAIN_ONLY=ethereum (to limit scope to specific chains)`)
         }
 
         const getDefiPositionsDetection: DefiPositionDetection = async (

--- a/packages/adapters-library/src/defiProvider.ts
+++ b/packages/adapters-library/src/defiProvider.ts
@@ -267,6 +267,13 @@ export class DefiProvider {
               )
             : filterTokenIds
 
+        // If no metadata is available and no filterTokenIds provided, pass undefined
+        // This allows adapters to fall back to their getTokenIds() method
+        const finalTokenIds =
+          combinedMetadata && combinedMetadata.length > 0
+            ? combinedMetadata
+            : undefined
+
         const poolsFilteredTime = Date.now()
 
         // Step 4: Call the adapter with the combined metadata
@@ -279,7 +286,7 @@ export class DefiProvider {
           userAddress,
           blockNumber,
           protocolTokenAddresses,
-          tokenIds: combinedMetadata, // This is the flattened metadata from all contracts
+          tokenIds: finalTokenIds, // This is the flattened metadata from all contracts, or undefined if no metadata
         })
 
         const positionsFetchedTime = Date.now()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Pass undefined tokenIds to adapters when no metadata is available to enable adapter fallbacks, and reformat/simplify the CLI cache setup guidance.
> 
> - **Adapters Library** (`packages/adapters-library/src/defiProvider.ts`):
>   - When no combined metadata is available, set `tokenIds` to `undefined` (via `finalTokenIds`) before calling `adapter.getPositions`, enabling adapters to use their own `getTokenIds()` fallback.
>   - Add concise comments clarifying metadata handling and fallback behavior.
> - **CLI** (`packages/adapters-cli/src/commands/library-commands.ts`):
>   - Reformat the “local cache” setup message in `positions` command output; simplify indentation and remove the extra warning line.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c3e8511085b72bda4e7e217a945a760ae7733e8f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->