### PR TITLE
Use environment variable for BASE_URL in pricesV2UsdAdapter

### DIFF
--- a/packages/adapters-library/src/adapters/prices-v2/products/usd/pricesV2UsdAdapter.ts
+++ b/packages/adapters-library/src/adapters/prices-v2/products/usd/pricesV2UsdAdapter.ts
@@ -19,7 +19,7 @@ import { ChainLink__factory, OneInchOracle__factory } from '../../contracts'
 import { fiatDecimals, priceAdapterConfig } from './priceV2Config'
 
 export const USD = 'USD'
-const BASE_URL = 'https://price-api.metafi.codefi.network'
+const BASE_URL = process.env.PRICE_API ?? 'https://price-api.metafi.codefi.network'
 
 export interface SpotPrice {
   allTimeHigh?: number


### PR DESCRIPTION
## **Description**

<!--
Write a short description of the changes included in this pull request. Include relevant links to the protocol docs
-->

## **Pre-merge author checklist**

- [ ] A brief description of the protocol and adapters is added to the PR
- [ ] Files outside the protocol folder are not being edited and, if they are, it's clearly explained why in the PR
- [ ] `update me` comments are removed
- [ ] Contracts used are verified for that chain block explorer
- [ ] Test cases with a block number have been added to the `testCases.ts` file for every relevant method that has been implemented
  - [ ] positions
  - [ ] prices (unwrap)
- [ ] `getAddress` from `ethers`
  - [ ] Is used to parse hardcoded addresses
  - [ ] Is used to parse addresses that come from contract calls when it is not clear they'll be in checksum format
  - [ ] It is NOT used to parse addresses from input methods
  - [ ] It is NOT used to parse addresses from metadata
- [ ] For every adapter that extends `SimplePoolAdapter`
  - [ ] `getPositions` is not overwritten and, if it is, it's clearly explained why in the PR
  - [ ] `unwrap` is not overwritten and, if it is, it's clearly explained why in the PR
- [ ] If the adapters requires to fetch static data on-chain (e.g. pool ids, token metadata, etc)
  - [ ] The adapter implements `IMetadataBuilder`
  - [ ] The `buildMetadata` method is implemented with the `@CacheToFile` decorator
  - [ ] All the static data is stored within the metadata JSON file

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, isolated configuration change; risk is limited to misconfiguration of the environment variable causing requests to target the wrong endpoint.
> 
> **Overview**
> The `PricesV2UsdAdapter` now reads the spot-price API `BASE_URL` from `process.env.PRICE_API`, falling back to the existing `https://price-api.metafi.codefi.network` default when unset.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6bf0c8c7f2d4aad48e35cbbf24f692db868e276b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->